### PR TITLE
Added error handling for Kraken::getAvail

### DIFF
--- a/src/kraken.cpp
+++ b/src/kraken.cpp
@@ -49,9 +49,9 @@ double getAvail(Parameters& params, std::string currency) {
 
   while (json_object_size(result) == 0) {
     sleep(1.0);
-	*params.logFile << "<Kraken> Error with JSON: " << json_dumps(root, 0) << ". Retrying..." << std::endl;
+    *params.logFile << "<Kraken> Error with JSON: " << json_dumps(root, 0) << ". Retrying..." << std::endl;
     root = authRequest(params, "https://api.kraken.com", "/0/private/Balance");
-	result = json_object_get(root, "result");
+    result = json_object_get(root, "result");
   }
   
   double available = 0.0;


### PR DESCRIPTION
If the response contains no result, blackbird prints the error message and tries again.
This handles cases in which the API key is invalid, password is wrong, etc.
(works well on my Mac and on Debian@Raspberry)

