### PR TITLE
Change back to POST after Bitfinex workaround and call Kraken API less frequently

### DIFF
--- a/src/bitfinex.cpp
+++ b/src/bitfinex.cpp
@@ -14,7 +14,8 @@
 namespace Bitfinex {
 
 double getQuote(Parameters& params, bool isBid) {
-  json_t* root = getJsonFromUrl(params, "https://api.bitfinex.com/v1/ticker/btcusd", "");
+  bool GETRequest = true;
+  json_t* root = getJsonFromUrl(params, "https://api.bitfinex.com/v1/ticker/btcusd", "", GETRequest);
   const char* quote;
   double quoteValue;
   if (isBid) {
@@ -99,10 +100,11 @@ double getActivePos(Parameters& params) {
 
 double getLimitPrice(Parameters& params, double volume, bool isBid) {
   json_t* root;
+  bool GETRequest = true;
   if (isBid) {
-    root = json_object_get(getJsonFromUrl(params, "https://api.bitfinex.com/v1/book/btcusd", ""), "bids");
+    root = json_object_get(getJsonFromUrl(params, "https://api.bitfinex.com/v1/book/btcusd", "", GETRequest), "bids");
   } else {
-    root = json_object_get(getJsonFromUrl(params, "https://api.bitfinex.com/v1/book/btcusd", ""), "asks");
+    root = json_object_get(getJsonFromUrl(params, "https://api.bitfinex.com/v1/book/btcusd", "", GETRequest), "asks");
   }
   *params.logFile << "<Bitfinex> Looking for a limit price to fill " << fabs(volume) << " BTC..." << std::endl;
   double tmpVol = 0.0;

--- a/src/bitstamp.cpp
+++ b/src/bitstamp.cpp
@@ -17,7 +17,8 @@
 namespace Bitstamp {
 
 double getQuote(Parameters& params, bool isBid) {
-  json_t* root = getJsonFromUrl(params, "https://www.bitstamp.net/api/ticker/", "");
+  bool GETRequest = false;
+  json_t* root = getJsonFromUrl(params, "https://www.bitstamp.net/api/ticker/", "", GETRequest);
   const char* quote;
   double quoteValue;
   if (isBid) {
@@ -92,11 +93,12 @@ double getActivePos(Parameters& params) {
 }
 
 double getLimitPrice(Parameters& params, double volume, bool isBid) {
+  bool GETRequest = false;
   json_t* root;
   if (isBid) {
-    root = json_object_get(getJsonFromUrl(params, "https://www.bitstamp.net/api/order_book/", ""), "bids");
+    root = json_object_get(getJsonFromUrl(params, "https://www.bitstamp.net/api/order_book/", "", GETRequest), "bids");
   } else {
-    root = json_object_get(getJsonFromUrl(params, "https://www.bitstamp.net/api/order_book/", ""), "asks");
+    root = json_object_get(getJsonFromUrl(params, "https://www.bitstamp.net/api/order_book/", "", GETRequest), "asks");
   }
   // loop on volume
   *params.logFile << "<Bitstamp> Looking for a limit price to fill " << fabs(volume) << " BTC..." << std::endl;

--- a/src/btce.cpp
+++ b/src/btce.cpp
@@ -9,7 +9,8 @@
 namespace BTCe {
 
 double getQuote(Parameters& params, bool isBid) {
-  json_t* root = getJsonFromUrl(params, "https://btc-e.com/api/3/ticker/btc_usd", "");
+  bool GETRequest = false;
+  json_t* root = getJsonFromUrl(params, "https://btc-e.com/api/3/ticker/btc_usd", "", GETRequest);
   double quoteValue;
   if (isBid) {
     quoteValue = json_real_value(json_object_get(json_object_get(root, "btc_usd"), "buy"));

--- a/src/curl_fun.cpp
+++ b/src/curl_fun.cpp
@@ -25,7 +25,6 @@ json_t* getJsonFromUrl(Parameters& params, std::string url, std::string postFiel
   if (getRequest) {
     curl_easy_setopt(params.curl, CURLOPT_CUSTOMREQUEST, "GET");
   }
-  *params.logFile << "URL: " << url << std::endl;
   CURLcode resCurl = curl_easy_perform(params.curl);
   while (resCurl != CURLE_OK) {
     *params.logFile << "Error with cURL: " << curl_easy_strerror(resCurl) << std::endl;

--- a/src/curl_fun.cpp
+++ b/src/curl_fun.cpp
@@ -54,6 +54,10 @@ json_t* getJsonFromUrl(Parameters& params, std::string url, std::string postFiel
     }
     root = json_loads(readBuffer.c_str(), 0, &error);
   }
+  // WORKAROUND FOR BITFINEX: CHANGE BACK TO POST REQUEST
+  if (strcmp(url.c_str(), "https://api.bitfinex.com/v1/book/btcusd") == 0) {
+    curl_easy_setopt(params.curl, CURLOPT_CUSTOMREQUEST, "POST");
+  }
   return root;
 }
 

--- a/src/curl_fun.h
+++ b/src/curl_fun.h
@@ -8,7 +8,7 @@
 
 size_t WriteCallback(void* contents, size_t size, size_t nmemb, void* userp);
 
-json_t* getJsonFromUrl(Parameters& params, std::string url, std::string postField);
+json_t* getJsonFromUrl(Parameters& params, std::string url, std::string postField, bool getRequest);
 
 #endif
 

--- a/src/gemini.cpp
+++ b/src/gemini.cpp
@@ -14,7 +14,8 @@
 namespace Gemini {
 
 double getQuote(Parameters& params, bool isBid) {
-  json_t* root = getJsonFromUrl(params, "https://api.gemini.com/v1/book/BTCUSD", "");
+  bool GETRequest = false;
+  json_t* root = getJsonFromUrl(params, "https://api.gemini.com/v1/book/BTCUSD", "", GETRequest);
   const char *quote;
   double quoteValue;
   if (isBid) {
@@ -87,11 +88,12 @@ double getActivePos(Parameters& params) {
 }
 
 double getLimitPrice(Parameters& params, double volume, bool isBid) {
+  bool GETRequest = false;
   json_t* root;
   if (isBid) {
-    root = json_object_get(getJsonFromUrl(params, "https://api.gemini.com/v1/book/btcusd", ""), "bids");
+    root = json_object_get(getJsonFromUrl(params, "https://api.gemini.com/v1/book/btcusd", "", GETRequest), "bids");
   } else {
-    root = json_object_get(getJsonFromUrl(params, "https://api.gemini.com/v1/book/btcusd", ""), "asks");
+    root = json_object_get(getJsonFromUrl(params, "https://api.gemini.com/v1/book/btcusd", "", GETRequest), "asks");
   }
   // loop on volume
   *params.logFile << "<Gemini> Looking for a limit price to fill " << fabs(volume) << " BTC..." << std::endl;

--- a/src/itbit.cpp
+++ b/src/itbit.cpp
@@ -9,7 +9,8 @@
 namespace ItBit {
 
 double getQuote(Parameters& params, bool isBid) {
-  json_t* root = getJsonFromUrl(params, "https://api.itbit.com/v1/markets/XBTUSD/ticker", "");
+  bool GETRequest = false;
+  json_t* root = getJsonFromUrl(params, "https://api.itbit.com/v1/markets/XBTUSD/ticker", "", GETRequest);
   const char* quote;
   double quoteValue;
   if (isBid) {

--- a/src/kraken.cpp
+++ b/src/kraken.cpp
@@ -24,7 +24,8 @@ namespace Kraken {
 static std::map<int, std::string> *id_to_transaction = new std::map<int, std::string>();
 
 double getQuote(Parameters& params, bool isBid) {
-  json_t* root = getJsonFromUrl(params, "https://api.kraken.com/0/public/Ticker", "pair=XXBTZUSD");
+  bool GETRequest = false;
+  json_t* root = getJsonFromUrl(params, "https://api.kraken.com/0/public/Ticker", "pair=XXBTZUSD", GETRequest);
   const char* quote;
   double quoteValue;
   if (isBid) {
@@ -113,7 +114,8 @@ double getActivePos(Parameters& params) {
 }
 
 double getLimitPrice(Parameters& params, double volume, bool isBid) {
-  json_t* root = json_object_get(json_object_get(getJsonFromUrl(params, "https://api.kraken.com/0/public/Depth", "pair=XXBTZUSD"), "result"), "XXBTZUSD");
+  bool GETRequest = false;
+  json_t* root = json_object_get(json_object_get(getJsonFromUrl(params, "https://api.kraken.com/0/public/Depth", "pair=XXBTZUSD", GETRequest), "result"), "XXBTZUSD");
   if (isBid) {
     root = json_object_get(root, "bids");
   } else {

--- a/src/kraken.cpp
+++ b/src/kraken.cpp
@@ -21,11 +21,23 @@ namespace patch {
 
 namespace Kraken {
 
+json_t* krakenTicker;
+bool krakenGotTicker = false;
+json_t* krakenLimPrices;
+bool krakenGotLimPrice = false;
+
 static std::map<int, std::string> *id_to_transaction = new std::map<int, std::string>();
 
 double getQuote(Parameters& params, bool isBid) {
   bool GETRequest = false;
-  json_t* root = getJsonFromUrl(params, "https://api.kraken.com/0/public/Ticker", "pair=XXBTZUSD", GETRequest);
+  json_t* root;
+  if (krakenGotTicker) {
+    root = krakenTicker;
+    krakenGotTicker = false;
+  } else {
+    root = getJsonFromUrl(params, "https://api.kraken.com/0/public/Ticker", "pair=XXBTZUSD", GETRequest);
+    krakenGotTicker = true;
+  }
   const char* quote;
   double quoteValue;
   if (isBid) {
@@ -115,7 +127,14 @@ double getActivePos(Parameters& params) {
 
 double getLimitPrice(Parameters& params, double volume, bool isBid) {
   bool GETRequest = false;
-  json_t* root = json_object_get(json_object_get(getJsonFromUrl(params, "https://api.kraken.com/0/public/Depth", "pair=XXBTZUSD", GETRequest), "result"), "XXBTZUSD");
+  json_t* root;
+  if (krakenGotLimPrice) {
+    root = krakenLimPrices;
+    krakenGotLimPrice = false;
+  } else {
+    root = json_object_get(json_object_get(getJsonFromUrl(params, "https://api.kraken.com/0/public/Depth", "pair=XXBTZUSD", GETRequest), "result"), "XXBTZUSD");
+    krakenGotLimPrice = true;
+  }
   if (isBid) {
     root = json_object_get(root, "bids");
   } else {

--- a/src/kraken.cpp
+++ b/src/kraken.cpp
@@ -21,11 +21,6 @@ namespace patch {
 
 namespace Kraken {
 
-json_t* krakenTicker;
-bool krakenGotTicker = false;
-json_t* krakenLimPrice;
-bool krakenGotLimPrice = false;
-
 static std::map<int, std::string> *id_to_transaction = new std::map<int, std::string>();
 
 double getQuote(Parameters& params, bool isBid) {
@@ -51,7 +46,9 @@ double getQuote(Parameters& params, bool isBid) {
   } else {
     quoteValue = 0.0;
   }
-  json_decref(root);
+  if (!krakenGotTicker) {
+    json_decref(root);
+  }
   return quoteValue;
 }
 
@@ -153,7 +150,9 @@ double getLimitPrice(Parameters& params, double volume, bool isBid) {
   }
   double limPrice = 0.0;
   limPrice = atof(json_string_value(json_array_get(json_array_get(root, i-1), 0)));
-  json_decref(root);
+  if (!krakenGotLimPrice) {
+    json_decref(root);
+  }
   return limPrice;
 }
 

--- a/src/kraken.cpp
+++ b/src/kraken.cpp
@@ -23,7 +23,7 @@ namespace Kraken {
 
 json_t* krakenTicker;
 bool krakenGotTicker = false;
-json_t* krakenLimPrices;
+json_t* krakenLimPrice;
 bool krakenGotLimPrice = false;
 
 static std::map<int, std::string> *id_to_transaction = new std::map<int, std::string>();
@@ -37,6 +37,7 @@ double getQuote(Parameters& params, bool isBid) {
   } else {
     root = getJsonFromUrl(params, "https://api.kraken.com/0/public/Ticker", "pair=XXBTZUSD", GETRequest);
     krakenGotTicker = true;
+    krakenTicker = root;
   }
   const char* quote;
   double quoteValue;
@@ -129,11 +130,12 @@ double getLimitPrice(Parameters& params, double volume, bool isBid) {
   bool GETRequest = false;
   json_t* root;
   if (krakenGotLimPrice) {
-    root = krakenLimPrices;
+    root = krakenLimPrice;
     krakenGotLimPrice = false;
   } else {
     root = json_object_get(json_object_get(getJsonFromUrl(params, "https://api.kraken.com/0/public/Depth", "pair=XXBTZUSD", GETRequest), "result"), "XXBTZUSD");
     krakenGotLimPrice = true;
+    krakenLimPrice = root;
   }
   if (isBid) {
     root = json_object_get(root, "bids");

--- a/src/kraken.h
+++ b/src/kraken.h
@@ -5,6 +5,11 @@
 #include <string>
 #include "parameters.h"
 
+json_t* krakenTicker;
+bool krakenGotTicker = false;
+json_t* krakenLimPrice;
+bool krakenGotLimPrice = false;
+
 namespace Kraken {
 
 double getQuote(Parameters& params, bool isBid);

--- a/src/okcoin.cpp
+++ b/src/okcoin.cpp
@@ -13,7 +13,8 @@
 namespace OKCoin {
 
 double getQuote(Parameters& params, bool isBid) {
-  json_t* root = getJsonFromUrl(params, "https://www.okcoin.com/api/ticker.do?ok=1", "");
+  bool GETRequest = false;
+  json_t* root = getJsonFromUrl(params, "https://www.okcoin.com/api/ticker.do?ok=1", "", GETRequest);
   const char* quote;
   double quoteValue;
   if (isBid) {
@@ -112,10 +113,11 @@ double getActivePos(Parameters& params) {
 }
 
 double getLimitPrice(Parameters& params, double volume, bool isBid) {
+  bool GETRequest = false;
   json_t* root;
   double limPrice = 0.0;
   if (isBid) {
-    root = json_object_get(getJsonFromUrl(params, "https://www.okcoin.com/api/v1/depth.do", ""), "bids");
+    root = json_object_get(getJsonFromUrl(params, "https://www.okcoin.com/api/v1/depth.do", "", GETRequest), "bids");
     // loop on volume
     *params.logFile << "<OKCoin> Looking for a limit price to fill " << fabs(volume) << " BTC..." << std::endl;
     double tmpVol = 0.0;
@@ -131,7 +133,7 @@ double getLimitPrice(Parameters& params, double volume, bool isBid) {
     }
     limPrice = json_real_value(json_array_get(json_array_get(root, i-1), 0));
   } else {
-    root = json_object_get(getJsonFromUrl(params, "https://www.okcoin.com/api/v1/depth.do", ""), "asks");
+    root = json_object_get(getJsonFromUrl(params, "https://www.okcoin.com/api/v1/depth.do", "", GETRequest), "asks");
     // loop on volume
     *params.logFile << "<OKCoin> Looking for a limit price to fill " << fabs(volume) << " BTC..." << std::endl;
     double tmpVol = 0.0;

--- a/src/poloniex.cpp
+++ b/src/poloniex.cpp
@@ -14,7 +14,8 @@
 namespace Poloniex {
 
 double getQuote(Parameters& params, bool isBid) {
-  json_t* root = getJsonFromUrl(params, "https://poloniex.com/public?command=returnTicker", "");
+  bool GETRequest = false;
+  json_t* root = getJsonFromUrl(params, "https://poloniex.com/public?command=returnTicker", "", GETRequest);
   const char* quote;
   double quoteValue;
   if (isBid) {
@@ -111,11 +112,12 @@ double getLimitPrice(Parameters& params, double volume, bool isBid) {
   // This function needs to be implemented
   // The code below is given as a general guideline but needs to be rewritten
   // to match the Poloniex API
+  bool GETRequest = false;
   json_t* root;
   if (isBid) {
-    root = json_object_get(getJsonFromUrl(params, "", ""), "bids");
+    root = json_object_get(getJsonFromUrl(params, "", "", GETRequest), "bids");
   } else {
-    root = json_object_get(getJsonFromUrl(params, "", ""), "asks");
+    root = json_object_get(getJsonFromUrl(params, "", "", GETRequest), "asks");
   }
   *params.logFile << "<Poloniex> Looking for a limit price to fill " << fabs(volume) << " BTC..." << std::endl;
   double tmpVol = 0.0;

--- a/src/sevennintysix.cpp
+++ b/src/sevennintysix.cpp
@@ -14,7 +14,8 @@
 namespace SevenNintySix {
 
 double getQuote(Parameters& params, bool isBid) {
-  json_t* root = getJsonFromUrl(params, "http://api.796.com/v3/futures/ticker.html?type=weekly", "");
+  bool GETRequest = false;
+  json_t* root = getJsonFromUrl(params, "http://api.796.com/v3/futures/ticker.html?type=weekly", "", GETRequest);
   const char* quote;
   double quoteValue;
   if (isBid) {
@@ -86,11 +87,12 @@ double getActivePos(Parameters& params){
 }
 
 double getLimitPrice(Parameters& params, double volume, bool isBid){
+  bool GETRequest = false;
   json_t* root;
   if (isBid) {
-    root = json_object_get(getJsonFromUrl(params, "http://api.796.com/v3/futures/depth.html?type=weekly", ""), "bids");
+    root = json_object_get(getJsonFromUrl(params, "http://api.796.com/v3/futures/depth.html?type=weekly", "", GETRequest), "bids");
   } else {
-    root = json_object_get(getJsonFromUrl(params, "http://api.796.com/v3/futures/depth.html?type=weekly", ""), "asks");
+    root = json_object_get(getJsonFromUrl(params, "http://api.796.com/v3/futures/depth.html?type=weekly", "", GETRequest), "asks");
   }
   // loop on volume
   *params.logFile << "<SevenNintySix> Looking for a limit price to fill " << volume << "BTC..." << std::endl;


### PR DESCRIPTION
In PR #51 we needed to modify the curl options when looking at the Bitfinex books. However we need to change the settings back after this has been completed.