### PR TITLE
Fixed global variable declaration problem from Kraken changes

### DIFF
--- a/src/kraken.cpp
+++ b/src/kraken.cpp
@@ -19,6 +19,12 @@ namespace patch {
   }
 }
 
+// Initialise global variables
+json_t *krakenTicker;
+bool krakenGotTicker = false;
+json_t *krakenLimPrice;
+bool krakenGotLimPrice = false;
+
 namespace Kraken {
 
 static std::map<int, std::string> *id_to_transaction = new std::map<int, std::string>();

--- a/src/kraken.h
+++ b/src/kraken.h
@@ -5,10 +5,10 @@
 #include <string>
 #include "parameters.h"
 
-json_t* krakenTicker;
-bool krakenGotTicker = false;
-json_t* krakenLimPrice;
-bool krakenGotLimPrice = false;
+extern json_t* krakenTicker;
+extern bool krakenGotTicker;
+extern json_t* krakenLimPrice;
+extern bool krakenGotLimPrice;
 
 namespace Kraken {
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -35,6 +35,7 @@ typedef bool (*isOrderCompleteType) (Parameters& params, int orderId);
 typedef double (*getActivePosType) (Parameters& params);
 typedef double (*getLimitPriceType) (Parameters& params, double volume, bool isBid);
 
+
 int main(int argc, char** argv) {
   std::cout << "Blackbird Bitcoin Arbitrage" << std::endl;
   std::cout << "DISCLAIMER: USE THE SOFTWARE AT YOUR OWN RISK\n" << std::endl;


### PR DESCRIPTION
After my previous PR to reduce the number of calls to Kraken some people had compilation errors. Weirdly these did not effect me the originally but did when I re-cloned the repository from fresh. The issue was that the global variables were not defined properly. This is now fixed and everything should compile as expected.