### PR TITLE
Migrate sqlite3

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "extern/sqlite3"]
+	path = extern/sqlite3
+	url = https://github.com/greatwolf/sqlite3

--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,7 @@ OBJECTS = $(SOURCES:.cpp=.o)
 
 SQLITE3 = libsqlite3.a
 SQLITE3CLI = sqlite3
+SQLITE3LIBS :=
 
 ifndef VERBOSE
   Q := @
@@ -30,11 +31,15 @@ else
   CXXFLAGS += -O0 -g
 endif
 
+ifneq ($(OS),Windows_NT)
+  SQLITE3LIBS += -lpthread -ldl
+endif
+
 all: $(SQLITE3CLI) $(EXEC)
 
 $(SQLITE3CLI): shell.o $(SQLITE3)
 	@echo Linking $@:
-	$(Q)$(CC) $(LDFLAGS) $(LIB_DIR) $< -o $@ -lsqlite3
+	$(Q)$(CC) $(LDFLAGS) $(LIB_DIR) $< -o $@ -lsqlite3 $(SQLITE3LIBS)
 
 $(SQLITE3): sqlite3.o
 	@echo Archiving $@:

--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,20 @@
 # Blackbird Bitcoin Arbitrage Makefile
 
-override INC_DIR += -I ./src -I/usr/include/mysql/
-override LIB_DIR +=
+override INC_DIR += -I ./src -I ./extern/sqlite3/include -I/usr/include/mysql/
+override LIB_DIR += -L .
+CFLAGS   := -std=c99
 CXXFLAGS := -Wall -pedantic -std=c++11
 LDFLAGS  := 
-LDLIBS   := -lcrypto -ljansson -lcurl -lmysqlclient
+LDLIBS   := -lsqlite3 -lcrypto -ljansson -lcurl -lmysqlclient
+CC       := gcc
+
 
 EXEC = blackbird
 SOURCES = $(wildcard src/*.cpp) $(wildcard src/*/*.cpp)
 OBJECTS = $(SOURCES:.cpp=.o)
+
+SQLITE3 = libsqlite3.a
+SQLITE3CLI = sqlite3
 
 ifndef VERBOSE
   Q := @
@@ -17,20 +23,34 @@ else
 endif
 
 ifndef DEBUG
+  CFLAGS   += -O2 -DNDEBUG
   CXXFLAGS += -O2 -DNDEBUG
 else
+  CFLAGS   += -O0 -g
   CXXFLAGS += -O0 -g
 endif
 
-all: $(EXEC)
+all: $(SQLITE3CLI) $(EXEC)
 
-$(EXEC): $(OBJECTS)
+$(SQLITE3CLI): shell.o $(SQLITE3)
 	@echo Linking $@:
-	$(Q)$(CXX) $(LDFLAGS) $(LIB_DIR) $^ -o $@ $(LDLIBS)
+	$(Q)$(CC) $(LDFLAGS) $(LIB_DIR) $< -o $@ -lsqlite3
+
+$(SQLITE3): sqlite3.o
+	@echo Archiving $@:
+	$(Q)$(AR) $(ARFLAGS) $@ $^
+
+$(EXEC): $(SQLITE3) $(OBJECTS)
+	@echo Linking $@:
+	$(Q)$(CXX) $(LDFLAGS) $(LIB_DIR) $(OBJECTS) -o $@ $(LDLIBS)
 
 %.o: %.cpp
 	@echo Compiling $@:
 	$(Q)$(CXX) $(CXXFLAGS) $(INC_DIR) -c $< -o $@
+
+%.o: extern/sqlite3/src/%.c
+	@echo Compiling $@:
+	$(Q)$(CC) $(CFLAGS) $(INC_DIR) -c $< -o $@
 
 clean:
 	$(Q)rm -rf core $(OBJECTS)

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,11 @@
 # Blackbird Bitcoin Arbitrage Makefile
 
-override INC_DIR += -I ./src -I ./extern/sqlite3/include -I/usr/include/mysql/
+override INC_DIR += -I ./src -I ./extern/sqlite3/include
 override LIB_DIR += -L .
 CFLAGS   := -std=c99
 CXXFLAGS := -Wall -pedantic -std=c++11
 LDFLAGS  := 
-LDLIBS   := -lsqlite3 -lcrypto -ljansson -lcurl -lmysqlclient
+LDLIBS   := -lsqlite3 -lcrypto -ljansson -lcurl
 CC       := gcc
 
 

--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ $(SQLITE3): sqlite3.o
 
 $(EXEC): $(SQLITE3) $(OBJECTS)
 	@echo Linking $@:
-	$(Q)$(CXX) $(LDFLAGS) $(LIB_DIR) $(OBJECTS) -o $@ $(LDLIBS)
+	$(Q)$(CXX) $(LDFLAGS) $(LIB_DIR) $(OBJECTS) -o $@ $(LDLIBS) $(SQLITE3LIBS)
 
 %.o: %.cpp
 	@echo Compiling $@:

--- a/blackbird.conf
+++ b/blackbird.conf
@@ -32,11 +32,7 @@ SmtpServerAddress=
 ReceiverAddress=
 
 # Database settings
-UseDatabase=false
-DBHost=
-DBName=
-DBUser=
-DBPassword=
+DBFile=blackbird.db
 
 # Bitfinex
 BitfinexApiKey=

--- a/src/db_fun.cpp
+++ b/src/db_fun.cpp
@@ -1,33 +1,60 @@
+#include "parameters.h"
+#include "sqlite3.h"
 #include <iostream>
 #include <sstream>
-#include <mysql.h>
-#include "db_fun.h"
+#include <memory>
 
-int createDbConnection(Parameters& params) {
-  params.dbConn = mysql_init(NULL);
-  std::stringstream query;
-  if (params.dbConn == NULL) {
-    std::cout << mysql_error(params.dbConn) << std::endl;
-    return -1;
-  }
-  if (mysql_real_connect(params.dbConn, params.dbHost.c_str(), params.dbUser.c_str(), params.dbPassword.c_str(), NULL, 0, NULL, 0) == NULL) {
-    std::cout << mysql_error(params.dbConn) << std::endl;
-    mysql_close(params.dbConn);
-    return -1;
-  }
-  query << "USE " << params.dbName;
-  return mysql_query(params.dbConn, query.str().c_str());
+
+// define some helper overloads to ease sqlite resource management
+using scoped_sqlite3err = std::unique_ptr<char, decltype(&sqlite3_free)>;
+static sqlite3* sqlite3_open(const char *filename, int &err)
+{
+  sqlite3 *db;
+  err = sqlite3_open(filename, &db);
+  return db;
 }
 
-int createTable(std::string exchangeName, Parameters& params) {
+typedef int (*sqlite3_callback)(void*, int, char**, char**);
+static char* sqlite3_exec(sqlite3 *S, const char *sql, sqlite3_callback cb, void *udata, int &err)
+{
+  char *errmsg;
+  err = sqlite3_exec(S, sql, cb, udata, &errmsg);
+  return errmsg;
+}
+
+
+int createDbConnection(Parameters& params)
+{
+  int res;
+  params.dbConn.reset( sqlite3_open(params.dbFile.c_str(), res) );
+  
+  if (res != SQLITE_OK)
+    std::cerr << sqlite3_errmsg(params.dbConn.get()) << std::endl;
+
+  return res;
+}
+
+int createTable(std::string exchangeName, Parameters& params)
+{
   std::stringstream query;
   query << "CREATE TABLE IF NOT EXISTS `" << exchangeName << "` (Datetime DATETIME NOT NULL, bid DECIMAL(8, 2), ask DECIMAL(8, 2));";
-  return mysql_query(params.dbConn, query.str().c_str());
+  int res;
+  scoped_sqlite3err errmsg(sqlite3_exec(params.dbConn.get(), query.str().c_str(), nullptr, nullptr, res),
+                           sqlite3_free);
+  if (res != SQLITE_OK)
+    std::cerr << errmsg.get() << std::endl;
+
+  return res;
 }
 
 int addBidAskToDb(std::string exchangeName, std::string datetime, double bid, double ask, Parameters& params) {
   std::stringstream query;
   query << "INSERT INTO `" << exchangeName << "` VALUES ('" << datetime << "'," << bid << "," << ask << ");";
-  return mysql_query(params.dbConn, query.str().c_str());
-}
+  int res;
+  scoped_sqlite3err errmsg(sqlite3_exec(params.dbConn.get(), query.str().c_str(), nullptr, nullptr, res),
+                           sqlite3_free);
+  if (res != SQLITE_OK)
+    std::cerr << errmsg.get() << std::endl;
 
+  return res;
+}

--- a/src/db_fun.h
+++ b/src/db_fun.h
@@ -2,7 +2,8 @@
 #define DB_FUN_H
 
 #include <string>
-#include "parameters.h"
+
+struct Parameters;
 
 int createDbConnection(Parameters& params);
 
@@ -11,4 +12,3 @@ int createTable(std::string exchangeName, Parameters& params);
 int addBidAskToDb(std::string exchangeName, std::string datetime, double bid, double ask, Parameters& params);
 
 #endif
-

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -7,7 +7,7 @@
 #include <jansson.h>
 #include <curl/curl.h>
 #include <string.h>
-#include <mysql.h>
+
 #include "utils/base64.h"
 #include "bitcoin.h"
 #include "result.h"
@@ -60,12 +60,13 @@ int main(int argc, char** argv) {
       }
     }
   }
-  if (params.useDatabase) {
-    if (createDbConnection(params) != 0) {
-      std::cout << "ERROR: cannot connect to the database \'" << params.dbName << "\'\n" << std::endl;
-      return -1;
-    }
+
+  if (createDbConnection(params) != 0)
+  {
+    std::cerr << "ERROR: cannot connect to the database \'" << params.dbFile << "\'\n" << std::endl;
+    return -1;
   }
+
   // function arrays containing all the exchanges functions
   getQuoteType getQuote[10];
   getAvailType getAvail[10];
@@ -86,10 +87,10 @@ int main(int argc, char** argv) {
     isOrderComplete[index] = Bitfinex::isOrderComplete;
     getActivePos[index] = Bitfinex::getActivePos;
     getLimitPrice[index] = Bitfinex::getLimitPrice;
-    if (params.useDatabase) {
-      dbTableName[index] = "bitfinex";
-      createTable(dbTableName[index], params);
-    }
+
+    dbTableName[index] = "bitfinex";
+    createTable(dbTableName[index], params);
+
     index++;
   }
   if (params.okcoinApi.empty() == false || params.demoMode == true) {
@@ -101,10 +102,10 @@ int main(int argc, char** argv) {
     isOrderComplete[index] = OKCoin::isOrderComplete;
     getActivePos[index] = OKCoin::getActivePos;
     getLimitPrice[index] = OKCoin::getLimitPrice;
-    if (params.useDatabase) {
-      dbTableName[index] = "okcoin";
-      createTable(dbTableName[index], params);
-    }
+
+    dbTableName[index] = "okcoin";
+    createTable(dbTableName[index], params);
+
     index++;
   }
   if (params.bitstampClientId.empty() == false || params.demoMode == true) {
@@ -115,10 +116,10 @@ int main(int argc, char** argv) {
     isOrderComplete[index] = Bitstamp::isOrderComplete;
     getActivePos[index] = Bitstamp::getActivePos;
     getLimitPrice[index] = Bitstamp::getLimitPrice;
-    if (params.useDatabase) {
-      dbTableName[index] = "bitstamp";
-      createTable(dbTableName[index], params);
-    }
+
+    dbTableName[index] = "bitstamp";
+    createTable(dbTableName[index], params);
+
     index++;
   }
   if (params.geminiApi.empty() == false || params.demoMode == true) {
@@ -129,10 +130,10 @@ int main(int argc, char** argv) {
     isOrderComplete[index] = Gemini::isOrderComplete;
     getActivePos[index] = Gemini::getActivePos;
     getLimitPrice[index] = Gemini::getLimitPrice;
-    if (params.useDatabase) {
-      dbTableName[index] = "gemini";
-      createTable(dbTableName[index], params);
-    }
+
+    dbTableName[index] = "gemini";
+    createTable(dbTableName[index], params);
+
     index++;
   }
   if (params.krakenApi.empty() == false || params.demoMode == true) {
@@ -143,10 +144,10 @@ int main(int argc, char** argv) {
     isOrderComplete[index] = Kraken::isOrderComplete;
     getActivePos[index] = Kraken::getActivePos;
     getLimitPrice[index] = Kraken::getLimitPrice;
-    if (params.useDatabase) {
-      dbTableName[index] = "kraken";
-      createTable(dbTableName[index], params);
-    }
+
+    dbTableName[index] = "kraken";
+    createTable(dbTableName[index], params);
+
     index++;
   }
   if (params.itbitApi.empty() == false || params.demoMode == true) {
@@ -155,10 +156,10 @@ int main(int argc, char** argv) {
     getAvail[index] = ItBit::getAvail;
     getActivePos[index] = ItBit::getActivePos;
     getLimitPrice[index] = ItBit::getLimitPrice;
-    if (params.useDatabase) {
-      dbTableName[index] = "itbit";
-      createTable(dbTableName[index], params);
-    }
+
+    dbTableName[index] = "itbit";
+    createTable(dbTableName[index], params);
+
     index++;
   }
   if (params.btceApi.empty() == false || params.demoMode == true) {
@@ -167,10 +168,10 @@ int main(int argc, char** argv) {
     getAvail[index] = BTCe::getAvail;
     getActivePos[index] = BTCe::getActivePos;
     getLimitPrice[index] = BTCe::getLimitPrice;
-    if (params.useDatabase) {
-      dbTableName[index] = "btce";
-      createTable(dbTableName[index], params);
-    }
+
+    dbTableName[index] = "btce";
+    createTable(dbTableName[index], params);
+
     index++;
   }
   if (params.poloniexApi.empty() == false || params.demoMode == true) {
@@ -182,10 +183,10 @@ int main(int argc, char** argv) {
     isOrderComplete[index] = Poloniex::isOrderComplete;
     getActivePos[index] = Poloniex::getActivePos;
     getLimitPrice[index] = Poloniex::getLimitPrice;
-    if (params.useDatabase) {
-      dbTableName[index] = "poloniex";
-      createTable(dbTableName[index], params);
-    }
+
+    dbTableName[index] = "poloniex";
+    createTable(dbTableName[index], params);
+
     index++;
   }
   if (index < 2) {
@@ -211,9 +212,9 @@ int main(int argc, char** argv) {
   logFile << "|   Blackbird Bitcoin Arbitrage Log File   |" << std::endl;
   logFile << "--------------------------------------------\n" << std::endl;
   logFile << "Blackbird started on " << printDateTime() << "\n" << std::endl;
-  if (params.useDatabase) {
-    logFile << "Connected to database \'" << params.dbName << "\'\n" << std::endl;
-  }
+
+  logFile << "Connected to database \'" << params.dbFile << "\'\n" << std::endl;
+
   if (params.demoMode) {
     logFile << "Demo mode: trades won't be generated\n" << std::endl;
   }
@@ -325,9 +326,9 @@ int main(int argc, char** argv) {
     for (int i = 0; i < numExch; ++i) {
       double bid = getQuote[i](params, true);
       double ask = getQuote[i](params, false);
-      if (params.useDatabase) {
-        addBidAskToDb(dbTableName[i], printDateTimeDb(currTime), bid, ask, params);
-      }
+
+      addBidAskToDb(dbTableName[i], printDateTimeDb(currTime), bid, ask, params);
+
       if (bid == 0.0) {
         logFile << "   WARNING: " << params.exchName[i] << " bid is null" << std::endl;
       }
@@ -561,9 +562,7 @@ int main(int argc, char** argv) {
   // analysis loop exited, do some cleanup
   curl_easy_cleanup(params.curl);
   curl_global_cleanup();
-  if (params.useDatabase) {
-    mysql_close(params.dbConn);
-  }
+
   csvFile.close();
   logFile.close();
 

--- a/src/parameters.cpp
+++ b/src/parameters.cpp
@@ -1,9 +1,12 @@
+#include "parameters.h"
+#include "sqlite3.h"
 #include <iostream>
 #include <stdlib.h>
-#include "parameters.h"
 
 
-Parameters::Parameters(std::string fileName) {
+Parameters::Parameters(std::string fileName)
+  : dbConn(nullptr, sqlite3_close)
+{
 
   std::ifstream configFile(fileName.c_str());
   spreadEntry = getDouble(getParameter("SpreadEntry", configFile));
@@ -56,11 +59,9 @@ Parameters::Parameters(std::string fileName) {
   senderPassword = getParameter("SenderPassword", configFile);
   smtpServerAddress = getParameter("SmtpServerAddress", configFile);
   receiverAddress = getParameter("ReceiverAddress", configFile);
-  useDatabase = getBool(getParameter("UseDatabase", configFile));
-  dbHost = getParameter("DBHost", configFile);
-  dbName = getParameter("DBName", configFile);
-  dbUser = getParameter("DBUser", configFile);
-  dbPassword = getParameter("DBPassword", configFile);
+
+  dbFile = getParameter("DBFile", configFile);
+
   configFile.close();
 }
 

--- a/src/parameters.h
+++ b/src/parameters.h
@@ -4,8 +4,12 @@
 #include <fstream>
 #include <string>
 #include <vector>
+#include <memory>
 #include <curl/curl.h>
-#include <mysql.h>
+
+
+struct sqlite3;
+using sqlite3_deleter = int (*)(sqlite3 *);
 
 struct Parameters {
 
@@ -67,12 +71,9 @@ struct Parameters {
   std::string senderPassword;
   std::string smtpServerAddress;
   std::string receiverAddress;
-  bool useDatabase;
-  std::string dbHost;
-  std::string dbName;
-  std::string dbUser;
-  std::string dbPassword;
-  MYSQL* dbConn;
+
+  std::string dbFile;
+  std::unique_ptr<sqlite3, sqlite3_deleter> dbConn;
 
   Parameters(std::string fileName);
 


### PR DESCRIPTION
This PR switches out mysql in favor of sqlite3, originally suggested in issue #83. Latest version of sqlite is placed as a submodule under this project so it can be part of the build process. When git cloning or pulling, you may need to also do `git submodule update --init` so the submodules properly sync.

I'm unsure of whether to keep the `UseDatabase` config setting. I opted to remove it and have blackbird always use a db -- sqlite is lightweight enough that I didn't see a reason to not always have it enabled. The sqlite CLI shell is also included so you can inspect the `blackbird.db` file from outside the program.

Leave feedback and comments.