### PR TITLE
convert orderIds from int to long

### DIFF
--- a/src/exchange/bitfinex.cpp
+++ b/src/exchange/bitfinex.cpp
@@ -63,27 +63,27 @@ double getAvail(Parameters& params, std::string currency) {
   return availability;
 }
 
-int sendLongOrder(Parameters& params, std::string direction, double quantity, double price) {
+long sendLongOrder(Parameters& params, std::string direction, double quantity, double price) {
   return sendOrder(params, direction, quantity, price);
 }
 
-int sendShortOrder(Parameters& params, std::string direction, double quantity, double price) {
+long sendShortOrder(Parameters& params, std::string direction, double quantity, double price) {
   return sendOrder(params, direction, quantity, price);
 }
 
-int sendOrder(Parameters& params, std::string direction, double quantity, double price) {
+long sendOrder(Parameters& params, std::string direction, double quantity, double price) {
   *params.logFile << "<Bitfinex> Trying to send a \"" << direction << "\" limit order: " << quantity << "@$" << price << "..." << std::endl;
   std::ostringstream oss;
   oss << "\"symbol\":\"btcusd\", \"amount\":\"" << quantity << "\", \"price\":\"" << price << "\", \"exchange\":\"bitfinex\", \"side\":\"" << direction << "\", \"type\":\"limit\"";
   std::string options = oss.str();
   json_t* root = authRequest(params, "https://api.bitfinex.com/v1/order/new", "order/new", options);
-  int orderId = json_integer_value(json_object_get(root, "order_id"));
+  long orderId = json_integer_value(json_object_get(root, "order_id"));
   *params.logFile << "<Bitfinex> Done (order ID: " << orderId << ")\n" << std::endl;
   json_decref(root);
   return orderId;
 }
 
-bool isOrderComplete(Parameters& params, int orderId) {
+bool isOrderComplete(Parameters& params, long orderId) {
   if (orderId == 0) {
     return true;
   }

--- a/src/exchange/bitfinex.h
+++ b/src/exchange/bitfinex.h
@@ -13,13 +13,13 @@ double getQuote(Parameters& params, bool isBid);
 
 double getAvail(Parameters& params, std::string currency);
 
-int sendLongOrder(Parameters& params, std::string direction, double quantity, double price);
+long sendLongOrder(Parameters& params, std::string direction, double quantity, double price);
 
-int sendShortOrder(Parameters& params, std::string direction, double quantity, double price);
+long sendShortOrder(Parameters& params, std::string direction, double quantity, double price);
 
-int sendOrder(Parameters& params, std::string direction, double quantity, double price);
+long sendOrder(Parameters& params, std::string direction, double quantity, double price);
 
-bool isOrderComplete(Parameters& params, int orderId);
+bool isOrderComplete(Parameters& params, long orderId);
 
 double getActivePos(Parameters& params);
 

--- a/src/exchange/bitstamp.cpp
+++ b/src/exchange/bitstamp.cpp
@@ -59,7 +59,7 @@ double getAvail(Parameters& params, std::string currency) {
   return availability;
 }
 
-int sendLongOrder(Parameters& params, std::string direction, double quantity, double price) {
+long sendLongOrder(Parameters& params, std::string direction, double quantity, double price) {
   *params.logFile << "<Bitstamp> Trying to send a \"" << direction << "\" limit order: " << quantity << "@$" << price << "..." << std::endl;
   std::ostringstream oss;
   oss << "https://www.bitstamp.net/api/" << direction << "/";
@@ -69,7 +69,7 @@ int sendLongOrder(Parameters& params, std::string direction, double quantity, do
   oss << "amount=" << quantity << "&price=" << std::fixed << std::setprecision(2) << price;
   std::string options = oss.str();
   json_t* root = authRequest(params, url, options);
-  int orderId = json_integer_value(json_object_get(root, "id"));
+  long orderId = json_integer_value(json_object_get(root, "id"));
   if (orderId == 0) {
     *params.logFile << "<Bitstamp> Order ID = 0. Message: " << json_dumps(root, 0) << std::endl;
   }
@@ -78,7 +78,7 @@ int sendLongOrder(Parameters& params, std::string direction, double quantity, do
   return orderId;
 }
 
-bool isOrderComplete(Parameters& params, int orderId) {
+bool isOrderComplete(Parameters& params, long orderId) {
   if (orderId == 0) {
     return true;
   }

--- a/src/exchange/bitstamp.h
+++ b/src/exchange/bitstamp.h
@@ -11,9 +11,9 @@ double getQuote(Parameters& params, bool isBid);
 
 double getAvail(Parameters& params, std::string currency);
 
-int sendLongOrder(Parameters& params, std::string direction, double quantity, double price);
+long sendLongOrder(Parameters& params, std::string direction, double quantity, double price);
 
-bool isOrderComplete(Parameters& params, int orderId);
+bool isOrderComplete(Parameters& params, long orderId);
 
 double getActivePos(Parameters& params);
 

--- a/src/exchange/gemini.cpp
+++ b/src/exchange/gemini.cpp
@@ -65,19 +65,19 @@ double getAvail(Parameters& params, std::string currency) {
   return availability;
 }
 
-int sendLongOrder(Parameters& params, std::string direction, double quantity, double price) {
+long sendLongOrder(Parameters& params, std::string direction, double quantity, double price) {
   *params.logFile << "<Gemini> Trying to send a \"" << direction << "\" limit order: " << quantity << "@$" << price << "..." << std::endl;
   std::ostringstream oss;
   oss << "\"symbol\":\"BTCUSD\", \"amount\":\"" << quantity << "\", \"price\":\"" << price << "\", \"side\":\"" << direction << "\", \"type\":\"exchange limit\"";
   std::string options = oss.str();
   json_t* root = authRequest(params, "https://api.gemini.com/v1/order/new", "order/new", options);
-  int orderId = atoi(json_string_value(json_object_get(root, "order_id")));
+  long orderId = atol(json_string_value(json_object_get(root, "order_id")));
   *params.logFile << "<Gemini> Done (order ID: " << orderId << ")\n" << std::endl;
   json_decref(root);
   return orderId;
 }
 
-bool isOrderComplete(Parameters& params, int orderId) {
+bool isOrderComplete(Parameters& params, long orderId) {
   if (orderId == 0) {
     return true;
   }

--- a/src/exchange/gemini.h
+++ b/src/exchange/gemini.h
@@ -11,9 +11,9 @@ double getQuote(Parameters& params, bool isBid);
 
 double getAvail(Parameters& params, std::string currency);
 
-int sendLongOrder(Parameters& params, std::string direction, double quantity, double price);
+long sendLongOrder(Parameters& params, std::string direction, double quantity, double price);
 
-bool isOrderComplete(Parameters& params, int orderId);
+bool isOrderComplete(Parameters& params, long orderId);
 
 double getActivePos(Parameters& params);
 

--- a/src/exchange/kraken.cpp
+++ b/src/exchange/kraken.cpp
@@ -21,7 +21,7 @@ bool krakenGotLimPrice = false;
 
 namespace Kraken {
 
-static std::map<int, std::string> id_to_transaction;
+static std::map<long, std::string> id_to_transaction;
 
 double getQuote(Parameters& params, bool isBid) {
   bool GETRequest = false;
@@ -71,7 +71,7 @@ double getAvail(Parameters& params, std::string currency) {
   return available;
 }
 
-int sendLongOrder(Parameters& params, std::string direction, double quantity, double price) {
+long sendLongOrder(Parameters& params, std::string direction, double quantity, double price) {
   if (direction.compare("buy") != 0 && direction.compare("sell") != 0) {
     *params.logFile  << "<Kraken> Error: Neither \"buy\" nor \"sell\" selected" << std::endl;
     return 0;
@@ -90,14 +90,14 @@ int sendLongOrder(Parameters& params, std::string direction, double quantity, do
     exit(0);
   }
   std::string txid = json_string_value(json_array_get(json_object_get(root, "txid"), 0));
-  int max_id = id_to_transaction.size();
+  long max_id = id_to_transaction.size();
   id_to_transaction[max_id] = txid;
   *params.logFile << "<Kraken> Done (transaction ID: " << txid << ")\n" << std::endl;
   json_decref(root);
   return max_id;
 }
 
-bool isOrderComplete(Parameters& params, int orderId) {
+bool isOrderComplete(Parameters& params, long orderId) {
   json_t* root = authRequest(params, "https://api.kraken.com", "/0/private/OpenOrders");
   // no open order: return true
   root = json_object_get(json_object_get(root, "result"), "open");

--- a/src/exchange/kraken.h
+++ b/src/exchange/kraken.h
@@ -16,9 +16,9 @@ double getQuote(Parameters& params, bool isBid);
 
 double getAvail(Parameters& params, std::string currency);
 
-int sendLongOrder(Parameters& params, std::string direction, double quantity, double price);
+long sendLongOrder(Parameters& params, std::string direction, double quantity, double price);
 
-bool isOrderComplete(Parameters& params, int orderId);
+bool isOrderComplete(Parameters& params, long orderId);
 
 double getActivePos(Parameters& params);
 

--- a/src/exchange/okcoin.cpp
+++ b/src/exchange/okcoin.cpp
@@ -57,7 +57,7 @@ double getAvail(Parameters& params, std::string currency)
   return availability;
 }
 
-int sendLongOrder(Parameters& params, std::string direction, double quantity, double price) {
+long sendLongOrder(Parameters& params, std::string direction, double quantity, double price) {
   // signature
   std::ostringstream oss;
   oss << "amount=" << quantity << "&api_key=" << params.okcoinApi << "&price=" << price << "&symbol=btc_usd&type=" << direction << "&secret_key=" << params.okcoinSecret;
@@ -69,13 +69,13 @@ int sendLongOrder(Parameters& params, std::string direction, double quantity, do
   std::string content = oss.str();
   *params.logFile << "<OKCoin> Trying to send a \"" << direction << "\" limit order: " << quantity << "@$" << price << "..." << std::endl;
   json_t *root = authRequest(params, "https://www.okcoin.com/api/v1/trade.do", signature, content);
-  int orderId = json_integer_value(json_object_get(root, "order_id"));
+  long orderId = json_integer_value(json_object_get(root, "order_id"));
   *params.logFile << "<OKCoin> Done (order ID: " << orderId << ")\n" << std::endl;
   json_decref(root);
   return orderId;
 }
 
-int sendShortOrder(Parameters& params, std::string direction, double quantity, double price) {
+long sendShortOrder(Parameters& params, std::string direction, double quantity, double price) {
   // TODO
   // Unlike Bitfinex and Poloniex, on OKCoin the borrowing phase has to be done
   // as a separated step before being able to short sell.
@@ -90,7 +90,7 @@ int sendShortOrder(Parameters& params, std::string direction, double quantity, d
   return 0;
 }
 
-bool isOrderComplete(Parameters& params, int orderId)
+bool isOrderComplete(Parameters& params, long orderId)
 {
   if (orderId == 0) return true;
 

--- a/src/exchange/okcoin.h
+++ b/src/exchange/okcoin.h
@@ -13,11 +13,11 @@ double getQuote(Parameters& params, bool isBid);
 
 double getAvail(Parameters& params, std::string currency);
 
-int sendLongOrder(Parameters& params, std::string direction, double quantity, double price);
+long sendLongOrder(Parameters& params, std::string direction, double quantity, double price);
 
-int sendShortOrder(Parameters& params, std::string direction, double quantity, double price);
+long sendShortOrder(Parameters& params, std::string direction, double quantity, double price);
 
-bool isOrderComplete(Parameters& params, int orderId);
+bool isOrderComplete(Parameters& params, long orderId);
 
 double getActivePos(Parameters& params);
 

--- a/src/exchange/poloniex.cpp
+++ b/src/exchange/poloniex.cpp
@@ -37,17 +37,17 @@ double getAvail(Parameters& params, std::string currency) {
   return 0.0;
 }
 
-int sendLongOrder(Parameters& params, std::string direction, double quantity, double price) {
+long sendLongOrder(Parameters& params, std::string direction, double quantity, double price) {
   // TODO
   return 0;
 }
 
-int sendShortOrder(Parameters& params, std::string direction, double quantity, double price) {
+long sendShortOrder(Parameters& params, std::string direction, double quantity, double price) {
   // TODO
   return 0;
 }
 
-bool isOrderComplete(Parameters& params, int orderId) {
+bool isOrderComplete(Parameters& params, long orderId) {
   // TODO
   return false;
 }

--- a/src/exchange/poloniex.h
+++ b/src/exchange/poloniex.h
@@ -11,11 +11,11 @@ double getQuote(Parameters& params, bool isBid);
 
 double getAvail(Parameters& params, std::string currency);
 
-int sendLongOrder(Parameters& params, std::string direction, double quantity, double price);
+long sendLongOrder(Parameters& params, std::string direction, double quantity, double price);
 
-int sendShortOrder(Parameters& params, std::string direction, double quantity, double price);
+long sendShortOrder(Parameters& params, std::string direction, double quantity, double price);
 
-bool isOrderComplete(Parameters& params, int orderId);
+bool isOrderComplete(Parameters& params, long orderId);
 
 double getActivePos(Parameters& params);
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -27,8 +27,8 @@
 // typedef declarations needed for the function arrays
 typedef double (*getQuoteType) (Parameters& params, bool isBid);
 typedef double (*getAvailType) (Parameters& params, std::string currency);
-typedef int (*sendOrderType) (Parameters& params, std::string direction, double quantity, double price);
-typedef bool (*isOrderCompleteType) (Parameters& params, int orderId);
+typedef long (*sendOrderType) (Parameters& params, std::string direction, double quantity, double price);
+typedef bool (*isOrderCompleteType) (Parameters& params, long orderId);
 typedef double (*getActivePosType) (Parameters& params);
 typedef double (*getLimitPriceType) (Parameters& params, double volume, bool isBid);
 
@@ -425,8 +425,8 @@ int main(int argc, char** argv) {
               res.maxSpread[res.idExchLong][res.idExchShort] = -1.0;
               res.minSpread[res.idExchLong][res.idExchShort] = 1.0;
               res.trailing[res.idExchLong][res.idExchShort] = 1.0;
-              int longOrderId = 0;
-              int shortOrderId = 0;
+              long longOrderId = 0;
+              long shortOrderId = 0;
               longOrderId = sendLongOrder[res.idExchLong](params, "buy", volumeLong, limPriceLong);
               shortOrderId = sendShortOrder[res.idExchShort](params, "sell", volumeShort, limPriceShort);
               logFile << "Waiting for the two orders to be filled..." << std::endl;
@@ -492,8 +492,8 @@ int main(int argc, char** argv) {
           res.priceLongOut = limPriceLong;
           res.priceShortOut = limPriceShort;
           res.printExitInfo(*params.logFile);
-          int longOrderId = 0;
-          int shortOrderId = 0;
+          long longOrderId = 0;
+          long shortOrderId = 0;
           logFile << std::setprecision(6) << "BTC exposure on " << params.exchName[res.idExchLong] << ": " << volumeLong << std::setprecision(2) << std::endl;
           logFile << std::setprecision(6) << "BTC exposure on " << params.exchName[res.idExchShort] << ": " << volumeShort << std::setprecision(2) << std::endl;
           logFile << std::endl;


### PR DESCRIPTION
issue described here: https://github.com/butor/blackbird/issues/13

Seems that Bitfinex orderIds now are beyond int range