### PR TITLE
Fix build error - cexio - missing algorithm

### DIFF
--- a/src/exchanges/cexio.cpp
+++ b/src/exchanges/cexio.cpp
@@ -12,6 +12,7 @@
 #include <array>
 #include <chrono>
 #include <cmath>
+#include <algorithm>
 
 namespace Cexio {
 
@@ -53,10 +54,9 @@ quote_t getQuote(Parameters &params)
 double getAvail(Parameters& params, std::string currency)
 {
   double available = 0.0;
-  const char* returnedText = NULL;
-  transform(currency.begin(), currency.end(), currency.begin(), ::toupper);
+  std::transform(currency.begin(), currency.end(), currency.begin(), ::toupper);
   const char * curr_ = currency.c_str();
-    
+
   unique_json root { authRequest(params, "/balance/","") };
 
   const char * avail_str = json_string_value(json_object_get(json_object_get(root.get(), curr_), "available"));


### PR DESCRIPTION
Fixes failing build, cexio.cpp missing <algorithm> include (fixes #394).

Also removes unused variable - `returnedText`, which fixes following error:

```
Compiling src/exchanges/cexio.o:
src/exchanges/cexio.cpp: In function 'double Cexio::getAvail(Parameters&, std::__cxx11::string)':
src/exchanges/cexio.cpp:57:3: error: 'transform' is not a member of 'std'
   std::transform(currency.begin(), currency.end(), currency.begin(), ::toupper);
   ^
src/exchanges/cexio.cpp:56:15: warning: unused variable 'returnedText' [-Wunused-variable]
   const char* returnedText = NULL;
               ^
Makefile:53: recipe for target 'src/exchanges/cexio.o' failed
make: *** [src/exchanges/cexio.o] Error 1
The command '/bin/sh -c make -B' returned a non-zero code: 2
```