### PR TITLE
Format Kraken and remove errant json_dumps

### DIFF
--- a/src/exchanges/kraken.cpp
+++ b/src/exchanges/kraken.cpp
@@ -11,7 +11,8 @@
 #include <array>
 #include <ctime>
 
-namespace Kraken {
+namespace Kraken
+{
 
 // Initialise internal variables
 static unique_json krakenTicker = nullptr;
@@ -19,18 +20,21 @@ static bool krakenGotTicker = false;
 static unique_json krakenLimPrice = nullptr;
 static bool krakenGotLimPrice = false;
 
-static RestApi& queryHandle(Parameters &params)
+static RestApi &queryHandle(Parameters &params)
 {
-  static RestApi query ("https://api.kraken.com",
-                        params.cacert.c_str(), *params.logFile);
+  static RestApi query("https://api.kraken.com",
+                       params.cacert.c_str(), *params.logFile);
   return query;
 }
 
 quote_t getQuote(Parameters &params)
 {
-  if (krakenGotTicker) {
+  if (krakenGotTicker)
+  {
     krakenGotTicker = false;
-  } else {
+  }
+  else
+  {
     auto &exchange = queryHandle(params);
     krakenTicker.reset(exchange.getRequest("/0/public/Ticker?pair=XXBTZUSD"));
     krakenGotTicker = true;
@@ -45,32 +49,42 @@ quote_t getQuote(Parameters &params)
   return std::make_pair(bidValue, askValue);
 }
 
-double getAvail(Parameters& params, std::string currency) {
-  unique_json root { authRequest(params, "/0/private/Balance") };
+double getAvail(Parameters &params, std::string currency)
+{
+  unique_json root{authRequest(params, "/0/private/Balance")};
   json_t *result = json_object_get(root.get(), "result");
-  if (json_object_size(result) == 0) {
+  if (json_object_size(result) == 0)
+  {
     return 0.0;
   }
   double available = 0.0;
-  if (currency.compare("usd") == 0) {
-    const char * avail_str = json_string_value(json_object_get(result, "ZUSD"));
+  if (currency.compare("usd") == 0)
+  {
+    const char *avail_str = json_string_value(json_object_get(result, "ZUSD"));
     available = avail_str ? atof(avail_str) : 0.0;
-  } else if (currency.compare("btc") == 0) {
-    const char * avail_str = json_string_value(json_object_get(result, "XXBT"));
+  }
+  else if (currency.compare("btc") == 0)
+  {
+    const char *avail_str = json_string_value(json_object_get(result, "XXBT"));
     available = avail_str ? atof(avail_str) : 0.0;
-  } else {
+  }
+  else
+  {
     *params.logFile << "<Kraken> Currency not supported" << std::endl;
   }
   return available;
 }
 
-std::string sendLongOrder(Parameters& params, std::string direction, double quantity, double price) {
+std::string sendLongOrder(Parameters &params, std::string direction, double quantity, double price)
+{
   return sendOrder(params, direction, quantity, price);
 }
 
-std::string sendOrder(Parameters& params, std::string direction, double quantity, double price) {
-  if (direction.compare("buy") != 0 && direction.compare("sell") != 0) {
-    *params.logFile  << "<Kraken> Error: Neither \"buy\" nor \"sell\" selected" << std::endl;
+std::string sendOrder(Parameters &params, std::string direction, double quantity, double price)
+{
+  if (direction.compare("buy") != 0 && direction.compare("sell") != 0)
+  {
+    *params.logFile << "<Kraken> Error: Neither \"buy\" nor \"sell\" selected" << std::endl;
     return "0";
   }
   *params.logFile << "<Kraken> Trying to send a \"" << direction << "\" limit order: "
@@ -82,20 +96,24 @@ std::string sendOrder(Parameters& params, std::string direction, double quantity
   std::string pricelimit = std::to_string(price);
   std::string volume = std::to_string(quantity);
   std::string options = "pair=" + pair + "&type=" + type + "&ordertype=" + ordertype + "&price=" + pricelimit + "&volume=" + volume + "&trading_agreement=agree";
-  unique_json root { authRequest(params, "/0/private/AddOrder", options) };
+  unique_json root{authRequest(params, "/0/private/AddOrder", options)};
   json_t *res = json_object_get(root.get(), "result");
-  if (json_is_object(res) == 0) {
+  if (json_is_object(res) == 0)
+  {
     *params.logFile << json_dumps(root.get(), 0) << std::endl;
     exit(0);
   }
   std::string txid = json_string_value(json_array_get(json_object_get(res, "txid"), 0));
-  *params.logFile << "<Kraken> Done (transaction ID: " << txid << ")\n" << std::endl;
-  return txid; 
+  *params.logFile << "<Kraken> Done (transaction ID: " << txid << ")\n"
+                  << std::endl;
+  return txid;
 }
 
-std::string sendShortOrder(Parameters& params, std::string direction, double quantity, double price) {
-  if (direction.compare("buy") != 0 && direction.compare("sell") != 0) {
-    *params.logFile  << "<Kraken> Error: Neither \"buy\" nor \"sell\" selected" << std::endl;
+std::string sendShortOrder(Parameters &params, std::string direction, double quantity, double price)
+{
+  if (direction.compare("buy") != 0 && direction.compare("sell") != 0)
+  {
+    *params.logFile << "<Kraken> Error: Neither \"buy\" nor \"sell\" selected" << std::endl;
     return "0";
   }
   *params.logFile << "<Kraken> Trying to send a short \"" << direction << "\" limit order: "
@@ -110,41 +128,46 @@ std::string sendShortOrder(Parameters& params, std::string direction, double qua
   std::string leverage = "2";
   ordertype = "limit";
   options = "pair=" + pair + "&type=" + type + "&ordertype=" + ordertype + "&price=" + pricelimit + "&volume=" + volume + "&leverage=" + leverage + "&trading_agreement=agree";
-  unique_json root { authRequest(params, "/0/private/AddOrder", options) };
+  unique_json root{authRequest(params, "/0/private/AddOrder", options)};
   json_t *res = json_object_get(root.get(), "result");
-  if (json_is_object(res) == 0) {
+  if (json_is_object(res) == 0)
+  {
     *params.logFile << json_dumps(root.get(), 0) << std::endl;
     exit(0);
   }
   std::string txid = json_string_value(json_array_get(json_object_get(res, "txid"), 0));
-  *params.logFile << "<Kraken> Done (transaction ID: " << txid << ")\n" << std::endl;
+  *params.logFile << "<Kraken> Done (transaction ID: " << txid << ")\n"
+                  << std::endl;
   return txid;
 }
 
-bool isOrderComplete(Parameters& params, std::string orderId) {
-  unique_json root { authRequest(params, "/0/private/OpenOrders") };
+bool isOrderComplete(Parameters &params, std::string orderId)
+{
+  unique_json root{authRequest(params, "/0/private/OpenOrders")};
   // no open order: return true
   auto res = json_object_get(json_object_get(root.get(), "result"), "open");
-  if (json_object_size(res) == 0) {
+  if (json_object_size(res) == 0)
+  {
     *params.logFile << "<Kraken> No order exists" << std::endl;
     return true;
   }
-  auto dump = json_dumps(res, 0);
-  *params.logFile << dump << std::endl;
-  free(dump);
   res = json_object_get(res, orderId.c_str());
   // open orders exist but specific order not found: return true
-  if (json_object_size(res) == 0) {
+  if (json_object_size(res) == 0)
+  {
     *params.logFile << "<Kraken> Order " << orderId << " does not exist" << std::endl;
     return true;
-  // open orders exist and specific order was found: return false
-  } else {
+    // open orders exist and specific order was found: return false
+  }
+  else
+  {
     *params.logFile << "<Kraken> Order " << orderId << " still exists!" << std::endl;
     return false;
   }
 }
 
-double getActivePos(Parameters& params) {
+double getActivePos(Parameters &params)
+{
   return getAvail(params, "btc");
 }
 
@@ -166,20 +189,20 @@ double getLimitPrice(Parameters &params, double volume, bool isBid)
   double currVol = 0;
   unsigned int i;
   // [[<price>, <volume>, <timestamp>], [<price>, <volume>, <timestamp>], ...]
-  for(i = 0; i < json_array_size(branch); i++)
+  for (i = 0; i < json_array_size(branch); i++)
   {
     // volumes are added up until the requested volume is reached
     currVol = atof(json_string_value(json_array_get(json_array_get(branch, i), 1)));
     currPrice = atof(json_string_value(json_array_get(json_array_get(branch, i), 0)));
     totVol += currVol;
-    if(totVol >=  volume * params.orderBookFactor)
-        break;
+    if (totVol >= volume * params.orderBookFactor)
+      break;
   }
 
   return currPrice;
 }
 
-json_t* authRequest(Parameters& params, std::string request, std::string options)
+json_t *authRequest(Parameters &params, std::string request, std::string options)
 {
   // create nonce and POST data
   static uint64_t nonce = time(nullptr) * 4;
@@ -195,7 +218,7 @@ json_t* authRequest(Parameters& params, std::string request, std::string options
 
   std::string payload_for_signature = std::to_string(nonce) + post_data;
   SHA256((uint8_t *)payload_for_signature.c_str(), payload_for_signature.size(),
-         &sig_data[ sig_size - SHA256_DIGEST_LENGTH ]);
+         &sig_data[sig_size - SHA256_DIGEST_LENGTH]);
 
   std::string decoded_key = base64_decode(params.krakenSecret);
   uint8_t *hmac_digest = HMAC(EVP_sha512(),
@@ -203,10 +226,9 @@ json_t* authRequest(Parameters& params, std::string request, std::string options
                               sig_data.data(), sig_data.size(), NULL, NULL);
   std::string api_sign_header = base64_encode(hmac_digest, SHA512_DIGEST_LENGTH);
   // cURL header
-  std::array<std::string, 2> headers
-  {
-    "API-KEY:"  + params.krakenApi,
-    "API-Sign:" + api_sign_header,
+  std::array<std::string, 2> headers{
+      "API-KEY:" + params.krakenApi,
+      "API-Sign:" + api_sign_header,
   };
 
   // cURL request
@@ -216,42 +238,42 @@ json_t* authRequest(Parameters& params, std::string request, std::string options
                               post_data);
 }
 
-void testKraken(){
+void testKraken()
+{
 
-    Parameters params("bird.conf");
-    params.logFile = new std::ofstream("./test.log" , std::ofstream::trunc);
+  Parameters params("bird.conf");
+  params.logFile = new std::ofstream("./test.log", std::ofstream::trunc);
 
-    std::string orderId;
+  std::string orderId;
 
-    std::cout << "Current value LEG1_LEG2 bid: " << getQuote(params).bid() << std::endl;
-    std::cout << "Current value LEG1_LEG2 ask: " << getQuote(params).ask() << std::endl;
-    std::cout << "Current balance BTC: " << getAvail(params, "btc") << std::endl;
-    std::cout << "Current balance USD: " << getAvail(params, "usd")<< std::endl;
-    std::cout << "Current balance ETH: " << getAvail(params, "eth")<< std::endl;
-    std::cout << "Current balance XMR: " << getAvail(params, "xmr")<< std::endl;
-    std::cout << "current bid limit price for .09 units: " << getLimitPrice(params, 0.09, true) << std::endl;
-    std::cout << "Current ask limit price for .09 units: " << getLimitPrice(params, 0.09, false) << std::endl;
-    //std::cout << "Sending buy order for 0.01 XMR @ $100 USD - TXID: " << std::endl;
-    //orderId = sendLongOrder(params, "buy", 0.01, 100);
-    //std::cout << orderId << std::endl;
-    ///// if you don't wait bittrex won't recognize order for iscomplete
-    //sleep(5);
-    //std::cout << "Buy Order is complete: " << isOrderComplete(params, orderId) << std::endl;
+  std::cout << "Current value LEG1_LEG2 bid: " << getQuote(params).bid() << std::endl;
+  std::cout << "Current value LEG1_LEG2 ask: " << getQuote(params).ask() << std::endl;
+  std::cout << "Current balance BTC: " << getAvail(params, "btc") << std::endl;
+  std::cout << "Current balance USD: " << getAvail(params, "usd") << std::endl;
+  std::cout << "Current balance ETH: " << getAvail(params, "eth") << std::endl;
+  std::cout << "Current balance XMR: " << getAvail(params, "xmr") << std::endl;
+  std::cout << "current bid limit price for .09 units: " << getLimitPrice(params, 0.09, true) << std::endl;
+  std::cout << "Current ask limit price for .09 units: " << getLimitPrice(params, 0.09, false) << std::endl;
+  //std::cout << "Sending buy order for 0.01 XMR @ $100 USD - TXID: " << std::endl;
+  //orderId = sendLongOrder(params, "buy", 0.01, 100);
+  //std::cout << orderId << std::endl;
+  ///// if you don't wait bittrex won't recognize order for iscomplete
+  //sleep(5);
+  //std::cout << "Buy Order is complete: " << isOrderComplete(params, orderId) << std::endl;
 
-    //std::cout << "Sending Short XMR order for 0.177 XMR @BID! USD: ";
-    //orderId = sendShortOrder(params,"sell",0.133, getLimitPrice(params,0.133,true));
-    //std::cout << orderId << std::endl;
-    //std::cout << "Closing Short XMR order for .09 - TXID: ";
-    //orderId = sendShortOrder(params, "buy", 0.046, getLimitPrice(params,0.046, false));
-    //std::cout << orderId  << std::endl;
+  //std::cout << "Sending Short XMR order for 0.177 XMR @BID! USD: ";
+  //orderId = sendShortOrder(params,"sell",0.133, getLimitPrice(params,0.133,true));
+  //std::cout << orderId << std::endl;
+  //std::cout << "Closing Short XMR order for .09 - TXID: ";
+  //orderId = sendShortOrder(params, "buy", 0.046, getLimitPrice(params,0.046, false));
+  //std::cout << orderId  << std::endl;
 
-    //vanilla sell orders below
-    //std::cout << "Buy order is complete: " << isOrderComplete(params, orderId) << std::endl;
-    //std::cout << "Sending sell order for 0.01 XMR @ 5000 USD - TXID: " << std::endl ;
-    //orderId = sendLongOrder(params, "sell", 0.01, 5000);
-    //std:: cout << orderId << std::endl;
-    //std::cout << "Sell order is complete: " << isOrderComplete(params, orderId) << std::endl;
-    //std::cout << "Active Position: " << getActivePos(params);
+  //vanilla sell orders below
+  //std::cout << "Buy order is complete: " << isOrderComplete(params, orderId) << std::endl;
+  //std::cout << "Sending sell order for 0.01 XMR @ 5000 USD - TXID: " << std::endl ;
+  //orderId = sendLongOrder(params, "sell", 0.01, 5000);
+  //std:: cout << orderId << std::endl;
+  //std::cout << "Sell order is complete: " << isOrderComplete(params, orderId) << std::endl;
+  //std::cout << "Active Position: " << getActivePos(params);
 }
-
 }


### PR DESCRIPTION
Sorry, mixing a format with a change here --
relevant lines are removing 132-134.

` -auto dump = json_dumps(res, 0); `
`-*params.logFile << dump << std::endl `
`-free(dump);`

I think this can cause seg faults in some scenarios. 