### PR TITLE
Parallel Trades -- Do not merge

### DIFF
--- a/src/check_entry_exit.cpp
+++ b/src/check_entry_exit.cpp
@@ -9,68 +9,77 @@
 #include <numeric>
 #include <cmath>
 
-
-// Not sure to understand what's going on here ;-)
 template <typename T>
-static typename std::iterator_traits<T>::value_type compute_sd(T first, const T &last) {
+static typename std::iterator_traits<T>::value_type compute_sd(T first, const T &last)
+{
   using namespace std;
   typedef typename iterator_traits<T>::value_type value_type;
-  
-  auto n  = distance(first, last);
+
+  auto n = distance(first, last);
   auto mu = accumulate(first, last, value_type()) / n;
   auto squareSum = inner_product(first, last, first, value_type());
   return sqrt(squareSum / n - mu * mu);
 }
 
 // Returns a double as a string '##.##%'
-std::string percToStr(double perc) {
+std::string percToStr(double perc)
+{
   std::ostringstream s;
-  if (perc >= 0.0) s << " ";
+  if (perc >= 0.0)
+    s << " ";
   s << std::fixed << std::setprecision(2) << perc * 100.0 << "%";
   return s.str();
 }
 
-bool checkEntry(Bitcoin* btcLong, Bitcoin* btcShort, Result& res, Parameters& params) {
-  
-  if (!btcShort->getHasShort()) return false;
+bool checkEntry(Bitcoin *btcLong, Bitcoin *btcShort, Result &trade, Parameters &params)
+{
+
+  if (!btcShort->getHasShort())
+    return false;
 
   // Gets the prices and computes the spread
   double priceLong = btcLong->getAsk();
   double priceShort = btcShort->getBid();
   // If the prices are null we return a null spread
   // to avoid false opportunities
-  if (priceLong > 0.0 && priceShort > 0.0) {
-    res.spreadIn = (priceShort - priceLong) / priceLong;
-  } else {
-    res.spreadIn = 0.0;
+  if (priceLong > 0.0 && priceShort > 0.0)
+  {
+    trade.spreadIn = (priceShort - priceLong) / priceLong;
+  }
+  else
+  {
+    trade.spreadIn = 0.0;
   }
   int longId = btcLong->getId();
   int shortId = btcShort->getId();
 
   // We update the max and min spread if necessary
-  res.maxSpread[longId][shortId] = std::max(res.spreadIn, res.maxSpread[longId][shortId]);
-  res.minSpread[longId][shortId] = std::min(res.spreadIn, res.minSpread[longId][shortId]);
+  trade.maxSpread = std::max(trade.spreadIn, trade.maxSpread);
+  trade.minSpread = std::min(trade.spreadIn, trade.minSpread);
 
-  if (params.verbose) {
+  if (params.verbose)
+  {
     params.logFile->precision(2);
-    *params.logFile << "   " << btcLong->getExchName() << "/" << btcShort->getExchName() << ":\t" << percToStr(res.spreadIn);
-    *params.logFile << " [target " << percToStr(params.spreadEntry) << ", min " << percToStr(res.minSpread[longId][shortId]) << ", max " << percToStr(res.maxSpread[longId][shortId]) << "]";
+    *params.logFile << "   " << btcLong->getExchName() << "/" << btcShort->getExchName() << ":\t" << percToStr(trade.spreadIn);
+    *params.logFile << " [target " << percToStr(params.spreadEntry) << ", min " << percToStr(trade.minSpread) << ", max " << percToStr(trade.maxSpread) << "]";
+    // FIXME: Reimplement vol
     // The short-term volatility is computed and
     // displayed. No other action with it for
     // the moment.
-    if (params.useVolatility) {
-      if (res.volatility[longId][shortId].size() >= params.volatilityPeriod) {
-        auto stdev = compute_sd(begin(res.volatility[longId][shortId]), end(res.volatility[longId][shortId]));
-        *params.logFile << "  volat. " << stdev * 100.0 << "%";
-      } else {
-        *params.logFile << "  volat. n/a " << res.volatility[longId][shortId].size() << "<" << params.volatilityPeriod << " ";
-      }
-    }
+    // if (params.useVolatility) {
+    //   if (trade.volatility[longId][shortId].size() >= params.volatilityPeriod) {
+    //     auto stdev = compute_sd(begin(trade.volatility[longId][shortId]), end(res.volatility[longId][shortId]));
+    //     *params.logFile << "  volat. " << stdev * 100.0 << "%";
+    //   } else {
+    //     *params.logFile << "  volat. n/a " << res.volatility[longId][shortId].size() << "<" << params.volatilityPeriod << " ";
+    //   }
+    // }
     // Updates the trailing spread
     // TODO: explain what a trailing spread is.
     // See #12 on GitHub for the moment
-    if (res.trailing[longId][shortId] != -1.0) {
-      *params.logFile << "   trailing " << percToStr(res.trailing[longId][shortId]) << "  " << res.trailingWaitCount[longId][shortId] << "/" << params.trailingCount;
+    if (trade.trailing != -1.0)
+    {
+      *params.logFile << "   trailing " << percToStr(trade.trailing) << "  " << trade.trailingWaitCount << "/" << params.trailingCount;
     }
     // If one of the exchanges (or both) hasn't been implemented,
     // we mention in the log file that this spread is for info only.
@@ -84,122 +93,141 @@ bool checkEntry(Bitcoin* btcLong, Bitcoin* btcShort, Result& res, Parameters& pa
   // the opportunity found.
   if (!btcLong->getIsImplemented() ||
       !btcShort->getIsImplemented() ||
-      res.spreadIn == 0.0)
+      trade.spreadIn == 0.0)
     return false;
 
   // the trailing spread is reset for this pair,
   // because once the spread is *below*
   // SpreadEndtry. Again, see #12 on GitHub for
   // more details.
-  if (res.spreadIn < params.spreadEntry) {
-    res.trailing[longId][shortId] = -1.0;
-    res.trailingWaitCount[longId][shortId] = 0;
+  if (trade.spreadIn < params.spreadEntry)
+  {
+    trade.trailing = -1.0;
+    trade.trailingWaitCount = 0;
     return false;
   }
 
   // Updates the trailingSpread with the new value
-  double newTrailValue = res.spreadIn - params.trailingLim;
-  if (res.trailing[longId][shortId] == -1.0) {
-    res.trailing[longId][shortId] = std::max(newTrailValue, params.spreadEntry);
+  double newTrailValue = trade.spreadIn - params.trailingLim;
+  if (trade.trailing == -1.0)
+  {
+    trade.trailing = std::max(newTrailValue, params.spreadEntry);
     return false;
   }
 
-  if (newTrailValue >= res.trailing[longId][shortId]) {
-    res.trailing[longId][shortId] = newTrailValue;
-    res.trailingWaitCount[longId][shortId] = 0;
+  if (newTrailValue >= trade.trailing)
+  {
+    trade.trailing = newTrailValue;
+    trade.trailingWaitCount = 0;
   }
-  if (res.spreadIn >= res.trailing[longId][shortId]) {
-    res.trailingWaitCount[longId][shortId] = 0;
+  if (trade.spreadIn >= trade.trailing)
+  {
+    trade.trailingWaitCount = 0;
     return false;
   }
 
-  if (res.trailingWaitCount[longId][shortId] < params.trailingCount) {
-    res.trailingWaitCount[longId][shortId]++;
+  if (trade.trailingWaitCount < params.trailingCount)
+  {
+    trade.trailingWaitCount++;
     return false;
   }
 
   // Updates the Result structure with the information about
   // the two trades and return True (meaning an opportunity
   // was found).
-  res.idExchLong = longId;
-  res.idExchShort = shortId;
-  res.feesLong = btcLong->getFees();
-  res.feesShort = btcShort->getFees();
-  res.exchNameLong = btcLong->getExchName();
-  res.exchNameShort = btcShort->getExchName();
-  res.priceLongIn = priceLong;
-  res.priceShortIn = priceShort;
-  res.exitTarget = res.spreadIn - params.spreadTarget - 2.0*(res.feesLong + res.feesShort);
-  res.trailingWaitCount[longId][shortId] = 0;
+  trade.idExchLong = longId;
+  trade.idExchShort = shortId;
+  trade.feesLong = btcLong->getFees();
+  trade.feesShort = btcShort->getFees();
+  trade.exchNameLong = btcLong->getExchName();
+  trade.exchNameShort = btcShort->getExchName();
+  trade.priceLongIn = priceLong;
+  trade.priceShortIn = priceShort;
+  trade.exitTarget = trade.spreadIn - params.spreadTarget - 2.0 * (trade.feesLong + trade.feesShort);
+  trade.trailingWaitCount = 0;
   return true;
 }
 
-bool checkExit(Bitcoin* btcLong, Bitcoin* btcShort, Result& res, Parameters& params, time_t period) {
-  double priceLong  = btcLong->getBid();
+bool checkExit(Bitcoin *btcLong, Bitcoin *btcShort, Result &trade, Parameters &params, time_t period)
+{
+  double priceLong = btcLong->getBid();
   double priceShort = btcShort->getAsk();
-  if (priceLong > 0.0 && priceShort > 0.0) {
-    res.spreadOut = (priceShort - priceLong) / priceLong;
-  } else {
-    res.spreadOut = 0.0;
+  if (priceLong > 0.0 && priceShort > 0.0)
+  {
+    trade.spreadOut = (priceShort - priceLong) / priceLong;
   }
-  int longId = btcLong->getId();
-  int shortId = btcShort->getId();
+  else
+  {
+    trade.spreadOut = 0.0;
+  }
+  //int longId = btcLong->getId();
+  //int shortId = btcShort->getId();
 
-  res.maxSpread[longId][shortId] = std::max(res.spreadOut, res.maxSpread[longId][shortId]);
-  res.minSpread[longId][shortId] = std::min(res.spreadOut, res.minSpread[longId][shortId]);
+  trade.maxSpread = std::max(trade.spreadOut, trade.maxSpread);
+  trade.minSpread = std::min(trade.spreadOut, trade.minSpread);
 
-  if (params.verbose) {
+  if (params.verbose)
+  {
     params.logFile->precision(2);
-    *params.logFile << "   " << btcLong->getExchName() << "/" << btcShort->getExchName() << ":\t" << percToStr(res.spreadOut);
-    *params.logFile << " [target " << percToStr(res.exitTarget) << ", min " << percToStr(res.minSpread[longId][shortId]) << ", max " << percToStr(res.maxSpread[longId][shortId]) << "]";
+    *params.logFile << "   " << btcLong->getExchName() << "/" << btcShort->getExchName() << ":\t" << percToStr(trade.spreadOut);
+    *params.logFile << " [target " << percToStr(trade.exitTarget) << ", min " << percToStr(trade.minSpread) << ", max " << percToStr(trade.maxSpread) << "]";
+    // FIXME: reimplement vol
     // The short-term volatility is computed and
     // displayed. No other action with it for
     // the moment.
-    if (params.useVolatility) {
-      if (res.volatility[longId][shortId].size() >= params.volatilityPeriod) {
-        auto stdev = compute_sd(begin(res.volatility[longId][shortId]), end(res.volatility[longId][shortId]));
-        *params.logFile << "  volat. " << stdev * 100.0 << "%";
-      } else {
-        *params.logFile << "  volat. n/a " << res.volatility[longId][shortId].size() << "<" << params.volatilityPeriod << " ";
-      }
-    }
-    if (res.trailing[longId][shortId] != 1.0) {
-      *params.logFile << "   trailing " << percToStr(res.trailing[longId][shortId]) << "  " << res.trailingWaitCount[longId][shortId] << "/" << params.trailingCount;
+    // if (params.useVolatility) {
+    //   if (res.volatility[longId][shortId].size() >= params.volatilityPeriod) {
+    //     auto stdev = compute_sd(begin(res.volatility[longId][shortId]), end(res.volatility[longId][shortId]));
+    //     *params.logFile << "  volat. " << stdev * 100.0 << "%";
+    //   } else {
+    //     *params.logFile << "  volat. n/a " << res.volatility[longId][shortId].size() << "<" << params.volatilityPeriod << " ";
+    //   }
+    // }
+    if (trade.trailing != 1.0)
+    {
+      *params.logFile << "   trailing " << percToStr(trade.trailing) << "  " << trade.trailingWaitCount << "/" << params.trailingCount;
     }
   }
   *params.logFile << std::endl;
-  if (period - res.entryTime >= int(params.maxLength)) {
-    res.priceLongOut  = priceLong;
-    res.priceShortOut = priceShort;
+  if (period - trade.entryTime >= int(params.maxLength))
+  {
+    trade.priceLongOut = priceLong;
+    trade.priceShortOut = priceShort;
     return true;
   }
-  if (res.spreadOut == 0.0) return false;
-  if (res.spreadOut > res.exitTarget) {
-    res.trailing[longId][shortId] = 1.0;
-    res.trailingWaitCount[longId][shortId] = 0;
+  if (trade.spreadOut == 0.0)
+    return false;
+  if (trade.spreadOut > trade.exitTarget)
+  {
+    trade.trailing = 1.0;
+    trade.trailingWaitCount = 0;
     return false;
   }
 
-  double newTrailValue = res.spreadOut + params.trailingLim;
-  if (res.trailing[longId][shortId] == 1.0) {
-    res.trailing[longId][shortId] = std::min(newTrailValue, res.exitTarget);
+  double newTrailValue = trade.spreadOut + params.trailingLim;
+  if (trade.trailing == 1.0)
+  {
+    trade.trailing = std::min(newTrailValue, trade.exitTarget);
     return false;
   }
-  if (newTrailValue <= res.trailing[longId][shortId]) {
-    res.trailing[longId][shortId] = newTrailValue;
-    res.trailingWaitCount[longId][shortId] = 0;
+  if (newTrailValue <= trade.trailing)
+  {
+    trade.trailing = newTrailValue;
+    trade.trailingWaitCount = 0;
   }
-  if (res.spreadOut <= res.trailing[longId][shortId]) {
-    res.trailingWaitCount[longId][shortId] = 0;
+  if (trade.spreadOut <= trade.trailing)
+  {
+    trade.trailingWaitCount = 0;
     return false;
   }
-  if (res.trailingWaitCount[longId][shortId] < params.trailingCount) {
-    res.trailingWaitCount[longId][shortId]++;
+  if (trade.trailingWaitCount < params.trailingCount)
+  {
+    trade.trailingWaitCount++;
     return false;
   }
 
-  res.priceLongOut  = priceLong;
-  res.priceShortOut = priceShort;
-  res.trailingWaitCount[longId][shortId] = 0;
+  trade.priceLongOut = priceLong;
+  trade.priceShortOut = priceShort;
+  trade.trailingWaitCount = 0;
   return true;
 }

--- a/src/check_entry_exit.h
+++ b/src/check_entry_exit.h
@@ -13,11 +13,10 @@ std::string percToStr(double perc);
 
 // Checks for entry opportunity between two exchanges
 // and returns True if an opporunity is found.
-bool checkEntry(Bitcoin* btcLong, Bitcoin* btcShort, Result& res, Parameters& params);
+bool checkEntry(Bitcoin* btcLong, Bitcoin* btcShort, Result& trade, Parameters& params);
 
 // Checks for exit opportunity between two exchanges
 // and returns True if an opporunity is found.
-bool checkExit(Bitcoin* btcLong, Bitcoin* btcShort, Result& res, Parameters& params, std::time_t period);
+bool checkExit(Bitcoin* btcLong, Bitcoin* btcShort, Result& trade, Parameters& params, std::time_t period);
 
 #endif
-

--- a/src/db_fun.cpp
+++ b/src/db_fun.cpp
@@ -1,40 +1,45 @@
 #include "parameters.h"
 #include "unique_sqlite.hpp"
-
+#include "result.h"
 #include <iostream>
 #include <string>
-
+#include <sstream>
 
 // Defines some helper overloads to ease sqlite resource management
-namespace {
+namespace
+{
 template <typename UNIQUE_T>
-class sqlite_proxy {
+class sqlite_proxy
+{
   typename UNIQUE_T::pointer S;
   UNIQUE_T &owner;
 
 public:
   sqlite_proxy(UNIQUE_T &owner) : S(nullptr), owner(owner)
-  {}
-  ~sqlite_proxy()                           { owner.reset(S); }
-  operator typename UNIQUE_T::pointer* ()   { return &S;      }
+  {
+  }
+  ~sqlite_proxy() { owner.reset(S); }
+  operator typename UNIQUE_T::pointer *() { return &S; }
 };
 
 template <typename T, typename deleter>
-sqlite_proxy< std::unique_ptr<T, deleter> >
-acquire(std::unique_ptr<T, deleter> &owner) { return owner;   }
+sqlite_proxy<std::unique_ptr<T, deleter>>
+acquire(std::unique_ptr<T, deleter> &owner) { return owner; }
 }
 
-int createDbConnection(Parameters& params) {
+int createDbConnection(Parameters &params)
+{
   int res = sqlite3_open(params.dbFile.c_str(), acquire(params.dbConn));
-  
+
   if (res != SQLITE_OK)
     std::cerr << sqlite3_errmsg(params.dbConn.get()) << std::endl;
 
   return res;
 }
 
-int createTable(std::string exchangeName, Parameters& params) {
-  
+int createTable(std::string exchangeName, Parameters &params)
+{
+
   std::string query = "CREATE TABLE IF NOT EXISTS `" + exchangeName +
                       "` (Datetime DATETIME NOT NULL, bid DECIMAL(8, 2), ask DECIMAL(8, 2));";
   unique_sqlerr errmsg;
@@ -45,9 +50,10 @@ int createTable(std::string exchangeName, Parameters& params) {
   return res;
 }
 
-int addBidAskToDb(std::string exchangeName, std::string datetime, double bid, double ask, Parameters& params) {
+int addBidAskToDb(std::string exchangeName, std::string datetime, double bid, double ask, Parameters &params)
+{
   std::string query = "INSERT INTO `" + exchangeName +
-                      "` VALUES ('"   + datetime +
+                      "` VALUES ('" + datetime +
                       "'," + std::to_string(bid) +
                       "," + std::to_string(ask) + ");";
   unique_sqlerr errmsg;
@@ -55,5 +61,133 @@ int addBidAskToDb(std::string exchangeName, std::string datetime, double bid, do
   if (res != SQLITE_OK)
     std::cerr << errmsg.get() << std::endl;
 
+  return res;
+}
+
+int createTradeTable(Parameters &params)
+{
+  std::string query = "CREATE TABLE IF NOT EXISTS trades ("
+                      "idexchlong INT, idexchshort INT,"
+                      "exchnamelong TEXT, exchnameshort TEXT, exposure REAL,"
+                      "feeslong REAL, feesshort REAL, entryTime DATETIME, spreadin REAL,"
+                      "pricelongin REAL, priceshortin REAL, leg2bal REAL, exittarget REAL,"
+                      "longexchtradeid TEXT, shortexchtradeid TEXT, maxspread REAL, minspread REAL,"
+                      "trailing REAL, trailingwaitcount REAL, isclosed INT);";
+  unique_sqlerr errmsg;
+  int res = sqlite3_exec(params.dbConn.get(), query.c_str(), nullptr, nullptr, acquire(errmsg));
+  if (res != SQLITE_OK)
+    std::cerr << errmsg.get() << std::endl;
+
+  return res;
+}
+// TODO: Clean this shit and make closing optional in addtrades
+int addTradesToDb(Result &trade, Parameters &params, int closer)
+{
+  std::stringstream ss;
+  ss << "INSERT INTO trades"
+     << " (idexchlong, idexchshort, exchnamelong, exchnameshort,"
+     << " exposure, feeslong, feesshort, entryTime, spreadin, pricelongin, priceshortin, "
+     << "leg2bal, exittarget, longexchtradeid, shortexchtradeid, maxspread, minspread, trailing, "
+     << "trailingwaitcount, isclosed) "
+     << "VALUES ("
+     << trade.idExchLong << " ," << trade.idExchShort
+     << " ,'" << trade.exchNameLong << "' ,'" << trade.exchNameShort
+     << "' ," << trade.exposure
+     << " ," << trade.feesLong
+     << " ," << trade.feesShort
+     << " ," << trade.entryTime
+     << " ," << trade.spreadIn
+     << " ," << trade.priceLongIn
+     << " ," << trade.priceShortIn
+     << " ," << trade.leg2TotBalanceBefore
+     << " ," << trade.exitTarget
+     << " ,'" << trade.longExchTradeId.c_str()
+     << "' ,'" << trade.shortExchTradeId.c_str()
+     << "' ," << trade.maxSpread
+     << " ," << trade.minSpread
+     << " ," << trade.trailing
+     << " ," << trade.trailingWaitCount
+     << " ," << closer << ");";
+  std::string s = ss.str();
+  std::string concat = s;
+  unique_sqlerr errmsg;
+  int res = sqlite3_exec(params.dbConn.get(), concat.c_str(), nullptr, nullptr, acquire(errmsg));
+  if (res != SQLITE_OK)
+    std::cerr << errmsg.get() << std::endl;
+  return res;
+}
+int closeTradeInDb(Result &trade, Parameters &params)
+{
+  std::string query = "UPDATE trades SET isclosed='1' WHERE rowid=(SELECT rowid from trades WHERE (longExchTradeId='" + trade.longExchTradeId + "') OR (shortExchTradeId='" + trade.shortExchTradeId + "'));";
+  unique_sqlerr errmsg;
+  int res = sqlite3_exec(params.dbConn.get(), query.c_str(), nullptr, nullptr, acquire(errmsg));
+  if (res != SQLITE_OK)
+    std::cerr << errmsg.get() << std::endl;
+  return res;
+}
+
+int count_cb(void *data, int count, char **rows, char **)
+{
+  if (count == 1 && rows)
+  {
+    *static_cast<int *>(data) = atoi(rows[0]);
+    return 0;
+  }
+  return 1;
+}
+int getNumTradesOutstanding(Parameters &params)
+{
+  int count = 0;
+  std::string query = "SELECT count(*) FROM trades WHERE isclosed = 0";
+  /// waitttttt I could fill the whole thing with a cb function.....
+
+  unique_sqlerr errmsg;
+  int res = sqlite3_exec(params.dbConn.get(), query.c_str(), count_cb, &count, acquire(errmsg));
+  if (res != SQLITE_OK)
+    std::cerr << errmsg.get() << std::endl;
+  return count;
+}
+
+static int trades_cb(void *data, int argc, char **argv, char **azColName)
+{
+  std::vector<Result> *list = reinterpret_cast<std::vector<Result> *>(data);
+  Result d;
+  d.id = atoi(argv[0]);
+  d.idExchLong = atoi(argv[1]);
+  d.idExchShort = atoi(argv[2]);
+  d.exchNameLong = argv[3];
+  d.exchNameShort = argv[4];
+  d.exposure = atof(argv[5]);
+  d.feesLong = atof(argv[6]);
+  d.feesShort = atof(argv[7]);
+  d.entryTime = atof(argv[8]);
+  d.spreadIn = atof(argv[9]);
+  d.priceLongIn = atof(argv[10]);
+  d.priceShortIn = atof(argv[11]);
+  d.leg2TotBalanceBefore = atof(argv[12]);
+  d.exitTarget = atof(argv[13]);
+  d.longExchTradeId = argv[14];
+  d.shortExchTradeId = argv[15];
+  d.maxSpread = atof(argv[15]);
+  d.minSpread = atof(argv[16]);
+  d.trailing = atof(argv[16]);
+  d.trailingWaitCount = atof(argv[17]);
+  list->push_back(d);
+
+  return 0;
+}
+int getTradesFromDb(Parameters &params, std::vector<Result> &trade)
+{
+  std::string query = "SELECT rowid, idexchlong, idexchshort, exchnamelong, exchnameshort,"
+                      "exposure, feeslong, feesshort, entryTime, spreadin, pricelongin, priceshortin, "
+                      "leg2bal, exittarget, longexchtradeid, shortexchtradeid, maxspread, minspread, trailing, "
+                      "trailingwaitcount FROM trades WHERE isclosed = 0";
+  unique_sqlerr errmsg;
+
+  int res = sqlite3_exec(params.dbConn.get(), query.c_str(), trades_cb, &trade, acquire(errmsg));
+  if (res != SQLITE_OK)
+  {
+    std::cerr << errmsg.get() << std::endl;
+  }
   return res;
 }

--- a/src/db_fun.h
+++ b/src/db_fun.h
@@ -11,4 +11,14 @@ int createTable(std::string exchangeName, Parameters& params);
 
 int addBidAskToDb(std::string exchangeName, std::string datetime, double bid, double ask, Parameters& params);
 
+int createTradeTable(Parameters& params);
+
+int addTradesToDb(Result& trade, Parameters& params, int closer);
+
+int closeTradeInDb(Result& trade, Parameters& params);
+
+int getNumTradesOutstanding(Parameters &params);
+
+int getTradesFromDb(Parameters &params, std::vector<Result> &trade);
+
 #endif

--- a/src/exchanges/binance.h
+++ b/src/exchanges/binance.h
@@ -1,0 +1,28 @@
+#ifndef BINANCE_H
+#define BINANCE_H
+
+#include "quote_t.h"
+#include <string>
+
+struct Parameters;
+
+namespace Binance {
+
+quote_t getQuote(Parameters& params);
+
+double getAvail(Parameters& params, std::string currency);
+
+std::string sendLongOrder(Parameters& params, std::string direction, double quantity, double price);
+
+std::string sendShortOrder(Parameters& params, std::string direction, double quantity, double price);
+
+bool isOrderComplete(Parameters& params, std::string orderId);
+
+double getActivePos(Parameters& params, std::string orderId="");
+
+double getLimitPrice(Parameters& params, double volume, bool isBid);
+
+void testBinance();
+}
+
+#endif

--- a/src/exchanges/bittrex.cpp
+++ b/src/exchanges/bittrex.cpp
@@ -1,0 +1,268 @@
+#include "bittrex.h"
+#include "parameters.h"
+#include "utils/restapi.h"
+#include "unique_json.hpp"
+#include "hex_str.hpp"
+
+#include "openssl/sha.h"
+#include "openssl/hmac.h"
+#include <array>
+#include <algorithm>
+#include <ctime>
+#include <cctype>
+
+namespace Bittrex {
+static json_t* authRequest(Parameters &, std::string, std::string);
+static RestApi& queryHandle(Parameters &params)
+{
+  static RestApi query ("https://bittrex.com",
+                        params.cacert.c_str(), *params.logFile);
+  return query;
+}
+
+static json_t* checkResponse(std::ostream &logFile, json_t *root)
+{
+  auto errmsg = json_object_get(root, "error");
+  if (errmsg)
+    logFile << "<Bittrex> Error with response: "
+            << json_string_value(errmsg) << '\n';
+
+  return root;
+}
+
+quote_t getQuote(Parameters &params)
+{
+  auto &exchange = queryHandle(params);
+  std::string x;
+
+  x += "/api/v1.1/public/getticker?market=";
+  x += "USDT-BTC";
+  //params.leg2.c_str();
+
+  unique_json root {exchange.getRequest(x)};
+  
+  double quote = json_number_value(json_object_get(json_object_get(root.get(), "result"), "Bid"));
+  auto bidValue = quote ? quote : 0.0;
+
+  quote = json_number_value(json_object_get(json_object_get(root.get(), "result"), "Ask"));
+  auto askValue = quote ? quote : 0.0;
+
+  return std::make_pair(bidValue, askValue);
+}
+
+double getAvail(Parameters &params, std::string currency)
+{
+  std::string cur_str;
+  cur_str += "currency=";
+  if (currency.compare("USD")==0){
+    cur_str += "USDT";
+  }
+  else {
+    cur_str += currency.c_str();
+  }
+  unique_json root { authRequest(params, "/api/v1.1/account/getbalance", cur_str)};
+
+  double available = json_number_value(json_object_get(json_object_get(root.get(), "result"),"Available"));
+  return available;
+}
+// this function name is misleading it is not a "long" order but a non margin order.
+std::string sendLongOrder(Parameters& params, std::string direction, double quantity, double price) {
+  if (direction.compare("buy") != 0 && direction.compare("sell") != 0) {
+    *params.logFile  << "<Bittrex> Error: Neither \"buy\" nor \"sell\" selected" << std::endl;
+    return "0";
+  }
+  *params.logFile << "<Bittrex> Trying to send a \"" << direction << "\" limit order: "
+                  << std::setprecision(8) << quantity << " @ $"
+                  << std::setprecision(8) << price << "...\n";
+  std::string pair = "USDT-BTC";
+  std::string type = direction;
+  std::string pricelimit = std::to_string(price);
+  std::string volume = std::to_string(quantity);
+  std::string options = "market=" + pair + "&quantity=" + volume + "&rate=" + pricelimit;
+  std::string url = "/api/v1.1/market/" + direction + "limit";
+  unique_json root { authRequest(params, url, options) };
+  // theres some problem here that can produce a seg fault.
+  auto txid = json_string_value(json_object_get(json_object_get(root.get(), "result"), "uuid"));
+
+  *params.logFile << "<Bittrex> Done (transaction ID: " << txid << ")\n" << std::endl;
+  return txid;
+}
+//SUGGEST: probably not necessary
+std::string sendShortOrder(Parameters& params, std::string direction, double quantity, double price) {
+  if (direction.compare("buy") != 0 && direction.compare("sell") != 0) {
+    *params.logFile  << "<Bittrex> Error: Neither \"buy\" nor \"sell\" selected" << std::endl;
+    return "0";
+  }
+  *params.logFile << "<Bittrex> Trying to send a \"" << direction << "\" limit order: "
+                  << std::setprecision(8) << quantity << " @ $"
+                  << std::setprecision(8) << price << "...\n";
+  std::string pair = "USDT-BTC";
+  std::string pricelimit = std::to_string(price);
+  std::string volume = std::to_string(quantity);
+  std::string options = "market=" + pair + "&quantity=" + volume + "&rate=" + pricelimit;
+  unique_json root { authRequest(params, "/api/v1.1/market/selllimit", options) };
+  //theres so
+  auto txid = json_string_value(json_object_get(json_object_get(root.get(), "result"), "uuid"));
+
+  *params.logFile << "<Bittrex> Done (transaction ID: " << txid << ")\n" << std::endl;
+  return txid;
+}
+//This is not used at the moment, but could pull out send long/short order. Leaving as is for now
+std::string sendOrder(Parameters& params, std::string direction, double quantity, double price)
+{
+  *params.logFile << "<Bittrex> Trying to send a \"" << direction << "\" limit order: "
+                  << std::setprecision(6) << quantity << "@$"
+                  << std::setprecision(2) << price << "...\n";
+  std::ostringstream oss;
+  oss << "\"symbol\":\"btcusd\", \"amount\":\"" << quantity << "\", \"price\":\"" << price << "\", \"exchange\":\"bitfinex\", \"side\":\"" << direction << "\", \"type\":\"limit\"";
+  std::string options = oss.str();
+  unique_json root { authRequest(params, "/v1/order/new", options) };
+
+  auto orderId = std::to_string(json_integer_value(json_object_get(root.get(), "order_id")));
+  *params.logFile << "<Bittrex> Done (order ID: " << orderId << ")\n" << std::endl;
+  return orderId;
+}
+
+bool isOrderComplete(Parameters& params, std::string orderId)
+{
+  //TODO Build a real currency string for options here (or outside?)
+  unique_json root { authRequest(params, "/api/v1.1/market/getopenorders","market=USDT-BTC")};
+  auto res = json_object_get(root.get(), "result");
+  // loop through the array to check orders
+  std::string uuid;
+  bool tmp = true;
+  int i = 0;
+  int size = json_array_size (res);
+  if (json_array_size(res) == 0) {
+    *params.logFile << "<Bittrex> No orders exist" << std::endl;
+    return true;
+  }
+  while (i < size){
+    uuid = json_string_value(json_object_get(json_array_get(res,i),"OrderUuid"));
+    if (uuid.compare(orderId.c_str())==0){
+      *params.logFile << "<Bittrex> Order " << orderId << " still exists" << std::endl;
+      tmp = false;
+    }
+    i++;
+  }
+  if (tmp == true){
+    *params.logFile << "<Bittrex> Order " << orderId << " does not exist" << std::endl;
+  }
+  return tmp;  
+}
+
+double getActivePos(Parameters& params, std::string orderId) {
+  double activeSize = 0.0;
+  if (!orderId.empty()){
+    std::string uri = "/api/v1.1/account/getorder";
+    std::string builder = "uuid=";
+    builder += orderId.c_str();
+    unique_json root {authRequest(params, uri, builder) };
+    activeSize = json_number_value(json_object_get(json_object_get(root.get(), "result"),"Quantity"));
+  }
+  return activeSize;
+}
+
+double getLimitPrice(Parameters& params, double volume, bool isBid) {
+  // takes a quantity we want and if its a bid or not
+  auto &exchange  = queryHandle(params);
+  //TODO build a real URI string here
+  unique_json root { exchange.getRequest("/api/v1.1/public/getorderbook?market=USDT-BTC&type=both") };
+  auto bidask  = json_object_get(json_object_get(root.get(),"result"),isBid ? "buy" : "sell");
+    // loop on volume
+  *params.logFile << "<Bittrex> Looking for a limit price to fill "
+                  << std::setprecision(8) << fabs(volume) << " Legx...\n";
+  double tmpVol = 0.0;
+  double p = 0.0;
+  double v;
+  int i = 0;
+  while (tmpVol < fabs(volume) * params.orderBookFactor)
+  {
+    p = json_number_value(json_object_get(json_array_get(bidask, i), "Rate"));
+    v = json_number_value(json_object_get(json_array_get(bidask, i), "Quantity"));
+    *params.logFile << "<Bittrex> order book: "
+                    << std::setprecision(8) << v << "@$"
+                    << std::setprecision(8) << p << std::endl;
+    tmpVol += v;
+    i++;
+  }
+
+  return p;
+}
+
+// build auth request - needs to append apikey, nonce, and calculate HMAC 512 hash and include it under api sign header
+json_t* authRequest(Parameters &params, std::string request, std:: string options)
+{
+  //TODO: create nonce NOT respected right now so not calculating but could be added with  std::to_string(++nonce)
+  //static uint64_t nonce = time(nullptr) * 4;
+  // this message is the full uri for sig signing. 
+  auto msg = "https://bittrex.com" + request +"?apikey=" + params.bittrexApi.c_str() +"&nonce=0";
+  //append options to full uri and partial URI
+  std::string uri = request + "?apikey=" + params.bittrexApi + "&nonce=0";
+  if (!options.empty()){
+    msg += "&";
+    msg += options;
+    uri += "&";
+    uri += options;
+  }
+  // SHA512 of URI and API SECRET 
+  // this function grabs the HMAC hash (using sha512) of the secret and the full URI
+  uint8_t *hmac_digest = HMAC(EVP_sha512(),
+                              params.bittrexSecret.c_str(), params.bittrexSecret.size(),
+                              reinterpret_cast<const uint8_t *>(msg.data()),msg.size(), 
+                              NULL, NULL);
+  // creates a hex string of the hmac hash
+  std::string api_sign_header = hex_str(hmac_digest, hmac_digest + SHA512_DIGEST_LENGTH);
+  // create a base for appending the initial request domain
+  std::string postParams = "?apikey=" + params.bittrexApi +
+                           "&nonce=0";
+  //once again append the extra options 
+  if (!options.empty())
+  {
+    postParams += "&";
+    postParams += options;
+  }
+  std::array<std::string,1> headers
+  {
+    "apisign:" + api_sign_header
+  };
+  //curl the request
+  auto &exchange = queryHandle(params);
+  return checkResponse(*params.logFile, exchange.postRequest(uri, make_slist(std::begin(headers), std::end(headers)),
+                       postParams));
+}
+
+
+
+void testBittrex(){
+
+    Parameters params("bird.conf");
+    params.logFile = new std::ofstream("./test.log" , std::ofstream::trunc);
+
+    std::string orderId;
+
+    //std::cout << "Current value LEG1_LEG2 bid: " << getQuote(params).bid() << std::endl;
+    //std::cout << "Current value LEG1_LEG2 ask: " << getQuote(params).ask() << std::endl;
+    //std::cout << "Current balance XMR: " << getAvail(params, "XMR") << std::endl;
+    //std::cout << "Current balance USD: " << getAvail(params, "USD")<< std::endl;
+    //std::cout << "Current balance ETH: " << getAvail(params, "ETH")<< std::endl;
+    //std::cout << "Current balance BTC: " << getAvail(params, "BTC")<< std::endl;
+    //std::cout << "current bid limit price for 10 units: " << getLimitPrice(params, 10.0, true) << std::endl;
+    //std::cout << "Current ask limit price for 10 units: " << getLimitPrice(params, 10.0, false) << std::endl;
+    //std::cout << "Sending buy order for 0.01 XMR @ $100 USD - TXID: " << std::endl;
+    //orderId = sendLongOrder(params, "buy", 0.01, 100);
+    //std::cout << orderId << std::endl;
+    ///// if you don't wait bittrex won't recognize order for iscomplete
+    //sleep(5);
+    //std::cout << "Buy Order is complete: " << isOrderComplete(params, orderId) << std::endl;
+  
+    // TODO: Test sell orders, really should work though.
+    //std::cout << orderId << std::endl;
+    //std::cout << "Buy order is complete: " << isOrderComplete(params, orderId) << std::endl;
+    //std::cout << "Sending sell order for 0.01 XMR @ 5000 USD - TXID: " << std::endl ;
+    //orderId = sendLongOrder(params, "sell", 0.01, 5000);
+    //std:: cout << orderId << std::endl;
+    //std::cout << "Sell order is complete: " << isOrderComplete(params, orderId) << std::endl;
+    //std::cout << "Active Position: " << getActivePos(params, orderId);
+}
+}

--- a/src/exchanges/bittrex.h
+++ b/src/exchanges/bittrex.h
@@ -1,0 +1,28 @@
+#ifndef BITTREX_H
+#define BITTREX_H
+
+#include "quote_t.h"
+#include <string>
+
+struct Parameters;
+
+namespace Bittrex {
+
+quote_t getQuote(Parameters& params);
+
+double getAvail(Parameters& params, std::string currency);
+
+std::string sendLongOrder(Parameters& params, std::string direction, double quantity, double price);
+
+std::string sendShortOrder(Parameters& params, std::string direction, double quantity, double price);
+
+bool isOrderComplete(Parameters& params, std::string orderId);
+
+double getActivePos(Parameters& params, std::string orderId="");
+
+double getLimitPrice(Parameters& params, double volume, bool isBid);
+
+void testBittrex();
+}
+
+#endif

--- a/src/exchanges/gdax.h
+++ b/src/exchanges/gdax.h
@@ -1,244 +1,31 @@
-#include "gdax.h"
-#include "parameters.h"
-#include "utils/restapi.h"
-#include "unique_json.hpp"
-#include "utils/base64.h"
-#include "openssl/sha.h"
-#include "openssl/hmac.h"
-#include <iomanip>
-#include <vector>
-#include <array>
-#include <ctime>
-#include "hex_str.hpp"
+#ifndef GDAX_H
+#define GDAX_H
 
-namespace GDAX
-{
+#include "quote_t.h"
+#include <string>
+//QUESTION: Do I need to declare struct json_t here?
+struct json_t;
+struct Parameters;
 
-static RestApi &queryHandle(Parameters &params)
-{
-  static RestApi query("https://api.gdax.com",
-                       params.cacert.c_str(), *params.logFile);
-  return query;
+namespace GDAX {
+
+quote_t getQuote(Parameters& params);
+
+double getAvail(Parameters& params, std::string currency);
+
+double getActivePos(Parameters& params, std::string orderId = "");
+
+double getLimitPrice(Parameters& params, double volume, bool isBid);
+
+std::string sendLongOrder(Parameters& params, std::string direction, double quantity, double price);
+
+bool isOrderComplete(Parameters& params, std::string orderId);
+
+std::string gettime();
+
+json_t* authRequest(Parameters& params, std::string method, std::string request, const std::string &options);
+
+void testGDAX();
 }
 
-quote_t getQuote(Parameters &params)
-{
-  auto &exchange = queryHandle(params);
-  std::string pair;
-  pair = "/products/";
-  pair += params.leg1.c_str();
-  pair += "-";
-  pair += params.leg2.c_str();
-  pair += "/ticker";
-  unique_json root{exchange.getRequest(pair)};
-  const char *bid, *ask;
-  int unpack_fail = json_unpack(root.get(), "{s:s, s:s}", "bid", &bid, "ask", &ask);
-  if (unpack_fail)
-  {
-    bid = "0";
-    ask = "0";
-  }
-
-  return std::make_pair(std::stod(bid), std::stod(ask));
-}
-
-double getAvail(Parameters &params, std::string currency)
-{
-  unique_json root{authRequest(params, "GET", "/accounts", "")};
-  size_t arraySize = json_array_size(root.get());
-  double available = 0.0;
-  const char *currstr;
-  for (size_t i = 0; i < arraySize; i++)
-  {
-    std::string tmpCurrency = json_string_value(json_object_get(json_array_get(root.get(), i), "currency"));
-    if (tmpCurrency.compare(currency.c_str()) == 0)
-    {
-      currstr = json_string_value(json_object_get(json_array_get(root.get(), i), "available"));
-      if (currstr != NULL)
-      {
-        available = atof(currstr);
-      }
-      else
-      {
-        *params.logFile << "<GDAX> Error with currency string" << std::endl;
-        available = 0.0;
-      }
-    }
-  }
-  return available;
-}
-
-double getActivePos(Parameters &params, std::string orderId)
-{
-  double activeSize = 0.0;
-  if (!orderId.empty())
-  {
-    std::string uri = "/orders/";
-    uri += orderId.c_str();
-    unique_json root{authRequest(params, "GET", uri, "")};
-    activeSize = atof(json_string_value(json_object_get(root.get(), "size")));
-  }
-  return activeSize;
-}
-
-double getLimitPrice(Parameters &params, double volume, bool isBid)
-{
-  auto &exchange = queryHandle(params);
-  // TODO: Build a real URL with leg1 leg2 and auth post it
-  // FIXME: using level 2 order book - has aggregated data but should be sufficient for now.
-  unique_json root{exchange.getRequest("/products/BTC-USD/book?level=2")};
-  auto bidask = json_object_get(root.get(), isBid ? "bids" : "asks");
-  *params.logFile << "<GDAX> Looking for a limit price to fill "
-                  << std::setprecision(8) << fabs(volume) << " Legx...\n";
-  double tmpVol = 0.0;
-  double p = 0.0;
-  double v;
-  int i = 0;
-  while (tmpVol < fabs(volume) * params.orderBookFactor)
-  {
-    p = atof(json_string_value(json_array_get(json_array_get(bidask, i), 0)));
-    v = atof(json_string_value(json_array_get(json_array_get(bidask, i), 1)));
-    *params.logFile << "<GDAX> order book: "
-                    << std::setprecision(8) << v << " @$"
-                    << std::setprecision(8) << p << std::endl;
-    tmpVol += v;
-    i++;
-  }
-  return p;
-}
-
-std::string sendLongOrder(Parameters &params, std::string direction, double quantity, double price)
-{
-  if (direction.compare("buy") != 0 && direction.compare("sell") != 0)
-  {
-    *params.logFile << "<GDAX> Error: Neither \"buy\" nor \"sell\" selected" << std::endl;
-    return "0";
-  }
-  *params.logFile << "<GDAX> Trying to send a \"" << direction << "\" limit order: "
-                  << std::setprecision(8) << quantity << " @ $"
-                  << std::setprecision(8) << price << "...\n"
-                  << std::endl;
-  std::string pair = "BTC-USD";
-  std::string type = direction;
-  char buff[300];
-  snprintf(buff, 300, "{\"size\":\"%.8f\",\"price\":\"%.8f\",\"side\":\"%s\",\"product_id\": \"%s\"}", quantity, price, type.c_str(), pair.c_str());
-  unique_json root{authRequest(params, "POST", "/orders", buff)};
-  // error check this
-  auto txid = json_string_value(json_object_get(root.get(), "id"));
-  *params.logFile << "<GDAX> Done (transaction ID: " << txid << ")\n"
-                  << std::endl;
-  return txid;
-}
-
-bool isOrderComplete(Parameters &params, std::string orderId)
-{
-  unique_json root{authRequest(params, "GET", "/orders", "")};
-  size_t arraySize = json_array_size(root.get());
-  bool complete = true;
-  const char *idstr;
-  for (size_t i = 0; i < arraySize; i++)
-  {
-    std::string tmpId = json_string_value(json_object_get(json_array_get(root.get(), i), "id"));
-    if (tmpId.compare(orderId.c_str()) == 0)
-    {
-      idstr = json_string_value(json_object_get(json_array_get(root.get(), i), "status"));
-      *params.logFile << "<GDAX> Order still open (Status:" << idstr << ")" << std::endl;
-      complete = false;
-    }
-  }
-  return complete;
-}
-
-json_t *authRequest(Parameters &params, std::string method, std::string request, const std::string &options)
-{
-  // create timestamp
-  std::string nonce = gettime();
-  // create data string
-  std::string post_data = nonce + method + request + options;
-  // create decoded key
-  std::string decoded_key = base64_decode(params.gdaxSecret);
-
-  // Message Signature using HMAC-SHA256 of (NONCE+ METHOD + PATH + body)
-
-  uint8_t *hmac_digest = HMAC(EVP_sha256(),
-                              decoded_key.c_str(), decoded_key.length(),
-                              reinterpret_cast<const uint8_t *>(post_data.data()), post_data.size(), NULL, NULL);
-
-  // encode the HMAC to base64
-  std::string api_sign_header = base64_encode(hmac_digest, SHA256_DIGEST_LENGTH);
-  // cURL header
-  std::array<std::string, 5> headers{
-      "CB-ACCESS-KEY:" + params.gdaxApi,
-      "CB-ACCESS-SIGN:" + api_sign_header,
-      "CB-ACCESS-TIMESTAMP:" + nonce,
-      "CB-ACCESS-PASSPHRASE:" + params.gdaxPhrase,
-      "Content-Type: application/json; charset=utf-8",
-  };
-
-  // cURL request
-  auto &exchange = queryHandle(params);
-  //TODO: this sucks please do something better
-  if (method.compare("GET") == 0)
-  {
-    return exchange.getRequest(request, make_slist(std::begin(headers), std::end(headers)));
-  }
-  else if (method.compare("POST") == 0)
-  {
-    return exchange.postRequest(request, make_slist(std::begin(headers), std::end(headers)), options);
-  }
-  else
-  {
-    std::cout << "Error With Auth method. Exiting with code 0" << std::endl;
-    exit(0);
-  }
-}
-
-std::string gettime()
-{
-
-  timeval curTime;
-  gettimeofday(&curTime, NULL);
-  int milli = curTime.tv_usec / 1000;
-  char buffer[80];
-  strftime(buffer, 80, "%Y-%m-%dT%H:%M:%S", gmtime(&curTime.tv_sec));
-  char time_buffer2[200];
-  snprintf(time_buffer2, 200, "%s.%d000Z", buffer, milli);
-  snprintf(time_buffer2, 200, "%sZ", buffer);
-
-  time_t result = time(NULL);
-  long long result2 = result;
-  char buff4[40];
-  snprintf(buff4, 40, "%lld", result2);
-
-  char buff5[40];
-  snprintf(buff5, 40, "%lld.%d000", result2, milli);
-  return buff5;
-}
-void testGDAX()
-{
-
-  Parameters params("bird.conf");
-  params.logFile = new std::ofstream("./test.log", std::ofstream::trunc);
-
-  std::string orderId;
-
-  //std::cout << "Current value LEG1_LEG2 bid: " << getQuote(params).bid() << std::endl;
-  //std::cout << "Current value LEG1_LEG2 ask: " << getQuote(params).ask() << std::endl;
-  //std::cout << "Current balance BTC: " << getAvail(params, "BTC") << std::endl;
-  //std::cout << "Current balance USD: " << getAvail(params, "USD")<< std::endl;
-  //std::cout << "Current balance ETH: " << getAvail(params, "ETH")<< std::endl;
-  //std::cout << "Current balance BTC: " << getAvail(params, "BCH")<< std::endl;
-  //std::cout << "current bid limit price for 10 units: " << getLimitPrice(params, 10 , true) << std::endl;
-  //std::cout << "Current ask limit price for .09 units: " << getLimitPrice(params, 0.09, false) << std::endl;
-  //std::cout << "Sending buy order for 0.005 BTC @ ASK! USD - TXID: " << std::endl;
-  //orderId = sendLongOrder(params, "buy", 0.005, getLimitPrice(params,.005,false));
-  //std::cout << orderId << std::endl;
-  //std::cout << "Buy Order is complete: " << isOrderComplete(params, orderId) << std::endl;
-
-  //std::cout << "Sending sell order for 0.02 BTC @ 10000 USD - TXID: " << std::endl;
-  //orderId = sendLongOrder(params, "sell", 0.02, 10000);
-  //std::cout << orderId << std::endl;
-  //std::cout << "Sell order is complete: " << isOrderComplete(params, orderId) << std::endl;
-  //std::cout << "Active Position: " << getActivePos(params,orderId);
-}
-}
+#endif

--- a/src/exchanges/gdax.h
+++ b/src/exchanges/gdax.h
@@ -1,32 +1,244 @@
-#ifndef GDAX_H
-#define GDAX_H
+#include "gdax.h"
+#include "parameters.h"
+#include "utils/restapi.h"
+#include "unique_json.hpp"
+#include "utils/base64.h"
+#include "openssl/sha.h"
+#include "openssl/hmac.h"
+#include <iomanip>
+#include <vector>
+#include <array>
+#include <ctime>
+#include "hex_str.hpp"
 
-#include "quote_t.h"
-#include <string>
+namespace GDAX
+{
 
-struct json_t;
-struct Parameters;
-
-namespace GDAX {
-
-quote_t getQuote(Parameters& params);
-
-double getAvail(Parameters& params, std::string currency);
-
-double getActivePos(Parameters& params);
-
-double getLimitPrice(Parameters& params, double volume, bool isBid);
-
-std::string sendLongOrder(Parameters& params, std::string direction, double quantity, double price);
-
-bool isOrderComplete(Parameters& params, std::string orderId);
-
-json_t* authRequest(Parameters& params, std::string method, std::string request,const std::string &options);
-
-std::string gettime();
-
-void testGDAX();
-
+static RestApi &queryHandle(Parameters &params)
+{
+  static RestApi query("https://api.gdax.com",
+                       params.cacert.c_str(), *params.logFile);
+  return query;
 }
 
-#endif
+quote_t getQuote(Parameters &params)
+{
+  auto &exchange = queryHandle(params);
+  std::string pair;
+  pair = "/products/";
+  pair += params.leg1.c_str();
+  pair += "-";
+  pair += params.leg2.c_str();
+  pair += "/ticker";
+  unique_json root{exchange.getRequest(pair)};
+  const char *bid, *ask;
+  int unpack_fail = json_unpack(root.get(), "{s:s, s:s}", "bid", &bid, "ask", &ask);
+  if (unpack_fail)
+  {
+    bid = "0";
+    ask = "0";
+  }
+
+  return std::make_pair(std::stod(bid), std::stod(ask));
+}
+
+double getAvail(Parameters &params, std::string currency)
+{
+  unique_json root{authRequest(params, "GET", "/accounts", "")};
+  size_t arraySize = json_array_size(root.get());
+  double available = 0.0;
+  const char *currstr;
+  for (size_t i = 0; i < arraySize; i++)
+  {
+    std::string tmpCurrency = json_string_value(json_object_get(json_array_get(root.get(), i), "currency"));
+    if (tmpCurrency.compare(currency.c_str()) == 0)
+    {
+      currstr = json_string_value(json_object_get(json_array_get(root.get(), i), "available"));
+      if (currstr != NULL)
+      {
+        available = atof(currstr);
+      }
+      else
+      {
+        *params.logFile << "<GDAX> Error with currency string" << std::endl;
+        available = 0.0;
+      }
+    }
+  }
+  return available;
+}
+
+double getActivePos(Parameters &params, std::string orderId)
+{
+  double activeSize = 0.0;
+  if (!orderId.empty())
+  {
+    std::string uri = "/orders/";
+    uri += orderId.c_str();
+    unique_json root{authRequest(params, "GET", uri, "")};
+    activeSize = atof(json_string_value(json_object_get(root.get(), "size")));
+  }
+  return activeSize;
+}
+
+double getLimitPrice(Parameters &params, double volume, bool isBid)
+{
+  auto &exchange = queryHandle(params);
+  // TODO: Build a real URL with leg1 leg2 and auth post it
+  // FIXME: using level 2 order book - has aggregated data but should be sufficient for now.
+  unique_json root{exchange.getRequest("/products/BTC-USD/book?level=2")};
+  auto bidask = json_object_get(root.get(), isBid ? "bids" : "asks");
+  *params.logFile << "<GDAX> Looking for a limit price to fill "
+                  << std::setprecision(8) << fabs(volume) << " Legx...\n";
+  double tmpVol = 0.0;
+  double p = 0.0;
+  double v;
+  int i = 0;
+  while (tmpVol < fabs(volume) * params.orderBookFactor)
+  {
+    p = atof(json_string_value(json_array_get(json_array_get(bidask, i), 0)));
+    v = atof(json_string_value(json_array_get(json_array_get(bidask, i), 1)));
+    *params.logFile << "<GDAX> order book: "
+                    << std::setprecision(8) << v << " @$"
+                    << std::setprecision(8) << p << std::endl;
+    tmpVol += v;
+    i++;
+  }
+  return p;
+}
+
+std::string sendLongOrder(Parameters &params, std::string direction, double quantity, double price)
+{
+  if (direction.compare("buy") != 0 && direction.compare("sell") != 0)
+  {
+    *params.logFile << "<GDAX> Error: Neither \"buy\" nor \"sell\" selected" << std::endl;
+    return "0";
+  }
+  *params.logFile << "<GDAX> Trying to send a \"" << direction << "\" limit order: "
+                  << std::setprecision(8) << quantity << " @ $"
+                  << std::setprecision(8) << price << "...\n"
+                  << std::endl;
+  std::string pair = "BTC-USD";
+  std::string type = direction;
+  char buff[300];
+  snprintf(buff, 300, "{\"size\":\"%.8f\",\"price\":\"%.8f\",\"side\":\"%s\",\"product_id\": \"%s\"}", quantity, price, type.c_str(), pair.c_str());
+  unique_json root{authRequest(params, "POST", "/orders", buff)};
+  // error check this
+  auto txid = json_string_value(json_object_get(root.get(), "id"));
+  *params.logFile << "<GDAX> Done (transaction ID: " << txid << ")\n"
+                  << std::endl;
+  return txid;
+}
+
+bool isOrderComplete(Parameters &params, std::string orderId)
+{
+  unique_json root{authRequest(params, "GET", "/orders", "")};
+  size_t arraySize = json_array_size(root.get());
+  bool complete = true;
+  const char *idstr;
+  for (size_t i = 0; i < arraySize; i++)
+  {
+    std::string tmpId = json_string_value(json_object_get(json_array_get(root.get(), i), "id"));
+    if (tmpId.compare(orderId.c_str()) == 0)
+    {
+      idstr = json_string_value(json_object_get(json_array_get(root.get(), i), "status"));
+      *params.logFile << "<GDAX> Order still open (Status:" << idstr << ")" << std::endl;
+      complete = false;
+    }
+  }
+  return complete;
+}
+
+json_t *authRequest(Parameters &params, std::string method, std::string request, const std::string &options)
+{
+  // create timestamp
+  std::string nonce = gettime();
+  // create data string
+  std::string post_data = nonce + method + request + options;
+  // create decoded key
+  std::string decoded_key = base64_decode(params.gdaxSecret);
+
+  // Message Signature using HMAC-SHA256 of (NONCE+ METHOD + PATH + body)
+
+  uint8_t *hmac_digest = HMAC(EVP_sha256(),
+                              decoded_key.c_str(), decoded_key.length(),
+                              reinterpret_cast<const uint8_t *>(post_data.data()), post_data.size(), NULL, NULL);
+
+  // encode the HMAC to base64
+  std::string api_sign_header = base64_encode(hmac_digest, SHA256_DIGEST_LENGTH);
+  // cURL header
+  std::array<std::string, 5> headers{
+      "CB-ACCESS-KEY:" + params.gdaxApi,
+      "CB-ACCESS-SIGN:" + api_sign_header,
+      "CB-ACCESS-TIMESTAMP:" + nonce,
+      "CB-ACCESS-PASSPHRASE:" + params.gdaxPhrase,
+      "Content-Type: application/json; charset=utf-8",
+  };
+
+  // cURL request
+  auto &exchange = queryHandle(params);
+  //TODO: this sucks please do something better
+  if (method.compare("GET") == 0)
+  {
+    return exchange.getRequest(request, make_slist(std::begin(headers), std::end(headers)));
+  }
+  else if (method.compare("POST") == 0)
+  {
+    return exchange.postRequest(request, make_slist(std::begin(headers), std::end(headers)), options);
+  }
+  else
+  {
+    std::cout << "Error With Auth method. Exiting with code 0" << std::endl;
+    exit(0);
+  }
+}
+
+std::string gettime()
+{
+
+  timeval curTime;
+  gettimeofday(&curTime, NULL);
+  int milli = curTime.tv_usec / 1000;
+  char buffer[80];
+  strftime(buffer, 80, "%Y-%m-%dT%H:%M:%S", gmtime(&curTime.tv_sec));
+  char time_buffer2[200];
+  snprintf(time_buffer2, 200, "%s.%d000Z", buffer, milli);
+  snprintf(time_buffer2, 200, "%sZ", buffer);
+
+  time_t result = time(NULL);
+  long long result2 = result;
+  char buff4[40];
+  snprintf(buff4, 40, "%lld", result2);
+
+  char buff5[40];
+  snprintf(buff5, 40, "%lld.%d000", result2, milli);
+  return buff5;
+}
+void testGDAX()
+{
+
+  Parameters params("bird.conf");
+  params.logFile = new std::ofstream("./test.log", std::ofstream::trunc);
+
+  std::string orderId;
+
+  //std::cout << "Current value LEG1_LEG2 bid: " << getQuote(params).bid() << std::endl;
+  //std::cout << "Current value LEG1_LEG2 ask: " << getQuote(params).ask() << std::endl;
+  //std::cout << "Current balance BTC: " << getAvail(params, "BTC") << std::endl;
+  //std::cout << "Current balance USD: " << getAvail(params, "USD")<< std::endl;
+  //std::cout << "Current balance ETH: " << getAvail(params, "ETH")<< std::endl;
+  //std::cout << "Current balance BTC: " << getAvail(params, "BCH")<< std::endl;
+  //std::cout << "current bid limit price for 10 units: " << getLimitPrice(params, 10 , true) << std::endl;
+  //std::cout << "Current ask limit price for .09 units: " << getLimitPrice(params, 0.09, false) << std::endl;
+  //std::cout << "Sending buy order for 0.005 BTC @ ASK! USD - TXID: " << std::endl;
+  //orderId = sendLongOrder(params, "buy", 0.005, getLimitPrice(params,.005,false));
+  //std::cout << orderId << std::endl;
+  //std::cout << "Buy Order is complete: " << isOrderComplete(params, orderId) << std::endl;
+
+  //std::cout << "Sending sell order for 0.02 BTC @ 10000 USD - TXID: " << std::endl;
+  //orderId = sendLongOrder(params, "sell", 0.02, 10000);
+  //std::cout << orderId << std::endl;
+  //std::cout << "Sell order is complete: " << isOrderComplete(params, orderId) << std::endl;
+  //std::cout << "Active Position: " << getActivePos(params,orderId);
+}
+}

--- a/src/exchanges/kraken.cpp
+++ b/src/exchanges/kraken.cpp
@@ -11,8 +11,7 @@
 #include <array>
 #include <ctime>
 
-namespace Kraken
-{
+namespace Kraken {
 
 // Initialise internal variables
 static unique_json krakenTicker = nullptr;
@@ -20,22 +19,26 @@ static bool krakenGotTicker = false;
 static unique_json krakenLimPrice = nullptr;
 static bool krakenGotLimPrice = false;
 
-static RestApi &queryHandle(Parameters &params)
+static RestApi& queryHandle(Parameters &params)
 {
-  static RestApi query("https://api.kraken.com",
-                       params.cacert.c_str(), *params.logFile);
+  static RestApi query ("https://api.kraken.com",
+                        params.cacert.c_str(), *params.logFile);
   return query;
 }
 
 quote_t getQuote(Parameters &params)
 {
-  if (krakenGotTicker)
-  {
+  if (krakenGotTicker) {
     krakenGotTicker = false;
-  }
-  else
-  {
+  } else {
     auto &exchange = queryHandle(params);
+    //std::string getpairstr;
+    //getpairstr += "/0/public/Ticker";
+    //getpairstr += "?pair=X";
+    //getpairstr += params.leg1.c_str();
+    //getpairstr += "Z";
+    //getpairstr += params.leg2.c_str();
+    //krakenTicker.reset(exchange.getRequest(getpairstr));
     krakenTicker.reset(exchange.getRequest("/0/public/Ticker?pair=XXBTZUSD"));
     krakenGotTicker = true;
   }
@@ -49,42 +52,25 @@ quote_t getQuote(Parameters &params)
   return std::make_pair(bidValue, askValue);
 }
 
-double getAvail(Parameters &params, std::string currency)
-{
-  unique_json root{authRequest(params, "/0/private/Balance")};
+double getAvail(Parameters& params, std::string currency) {
+  unique_json root { authRequest(params, "/0/private/Balance") };
   json_t *result = json_object_get(root.get(), "result");
-  if (json_object_size(result) == 0)
-  {
-    return 0.0;
-  }
-  double available = 0.0;
-  if (currency.compare("usd") == 0)
-  {
-    const char *avail_str = json_string_value(json_object_get(result, "ZUSD"));
+  double available = 0.00;
+  if (currency.compare("USD") == 0) {
+    const char * avail_str = json_string_value(json_object_get(result, "ZUSD"));
     available = avail_str ? atof(avail_str) : 0.0;
-  }
-  else if (currency.compare("btc") == 0)
-  {
-    const char *avail_str = json_string_value(json_object_get(result, "XXBT"));
+  } else if (currency.compare("BTC") == 0) {
+    const char * avail_str = json_string_value(json_object_get(result, "XXBT"));
     available = avail_str ? atof(avail_str) : 0.0;
-  }
-  else
-  {
+  } else {
     *params.logFile << "<Kraken> Currency not supported" << std::endl;
   }
   return available;
 }
 
-std::string sendLongOrder(Parameters &params, std::string direction, double quantity, double price)
-{
-  return sendOrder(params, direction, quantity, price);
-}
-
-std::string sendOrder(Parameters &params, std::string direction, double quantity, double price)
-{
-  if (direction.compare("buy") != 0 && direction.compare("sell") != 0)
-  {
-    *params.logFile << "<Kraken> Error: Neither \"buy\" nor \"sell\" selected" << std::endl;
+std::string sendLongOrder(Parameters& params, std::string direction, double quantity, double price) {
+  if (direction.compare("buy") != 0 && direction.compare("sell") != 0) {
+    *params.logFile  << "<Kraken> Error: Neither \"buy\" nor \"sell\" selected" << std::endl;
     return "0";
   }
   *params.logFile << "<Kraken> Trying to send a \"" << direction << "\" limit order: "
@@ -95,25 +81,20 @@ std::string sendOrder(Parameters &params, std::string direction, double quantity
   std::string ordertype = "limit";
   std::string pricelimit = std::to_string(price);
   std::string volume = std::to_string(quantity);
-  std::string options = "pair=" + pair + "&type=" + type + "&ordertype=" + ordertype + "&price=" + pricelimit + "&volume=" + volume + "&trading_agreement=agree";
-  unique_json root{authRequest(params, "/0/private/AddOrder", options)};
+  std::string options = "pair=" + pair + "&type=" + type + "&ordertype=" + ordertype + "&price=" + pricelimit + "&volume=" + volume;
+  unique_json root { authRequest(params, "/0/private/AddOrder", options) };
   json_t *res = json_object_get(root.get(), "result");
-  if (json_is_object(res) == 0)
-  {
+  if (json_is_object(res) == 0) {
     *params.logFile << json_dumps(root.get(), 0) << std::endl;
     exit(0);
   }
   std::string txid = json_string_value(json_array_get(json_object_get(res, "txid"), 0));
-  *params.logFile << "<Kraken> Done (transaction ID: " << txid << ")\n"
-                  << std::endl;
+  *params.logFile << "<Kraken> Done (transaction ID: " << txid << ")\n" << std::endl;
   return txid;
 }
-
-std::string sendShortOrder(Parameters &params, std::string direction, double quantity, double price)
-{
-  if (direction.compare("buy") != 0 && direction.compare("sell") != 0)
-  {
-    *params.logFile << "<Kraken> Error: Neither \"buy\" nor \"sell\" selected" << std::endl;
+std::string sendShortOrder(Parameters& params, std::string direction, double quantity, double price) {
+  if (direction.compare("buy") != 0 && direction.compare("sell") != 0) {
+    *params.logFile  << "<Kraken> Error: Neither \"buy\" nor \"sell\" selected" << std::endl;
     return "0";
   }
   *params.logFile << "<Kraken> Trying to send a short \"" << direction << "\" limit order: "
@@ -128,47 +109,51 @@ std::string sendShortOrder(Parameters &params, std::string direction, double qua
   std::string leverage = "2";
   ordertype = "limit";
   options = "pair=" + pair + "&type=" + type + "&ordertype=" + ordertype + "&price=" + pricelimit + "&volume=" + volume + "&leverage=" + leverage + "&trading_agreement=agree";
-  unique_json root{authRequest(params, "/0/private/AddOrder", options)};
+  
+  unique_json root { authRequest(params, "/0/private/AddOrder", options) };
   json_t *res = json_object_get(root.get(), "result");
-  if (json_is_object(res) == 0)
-  {
+  if (json_is_object(res) == 0) {
     *params.logFile << json_dumps(root.get(), 0) << std::endl;
     exit(0);
   }
   std::string txid = json_string_value(json_array_get(json_object_get(res, "txid"), 0));
-  *params.logFile << "<Kraken> Done (transaction ID: " << txid << ")\n"
-                  << std::endl;
+  *params.logFile << "<Kraken> Done (transaction ID: " << txid << ")\n" << std::endl;
   return txid;
 }
 
-bool isOrderComplete(Parameters &params, std::string orderId)
-{
-  unique_json root{authRequest(params, "/0/private/OpenOrders")};
+bool isOrderComplete(Parameters& params, std::string orderId) {
+  unique_json root { authRequest(params, "/0/private/OpenOrders") };
   // no open order: return true
   auto res = json_object_get(json_object_get(root.get(), "result"), "open");
-  if (json_object_size(res) == 0)
-  {
+  if (json_object_size(res) == 0) {
     *params.logFile << "<Kraken> No order exists" << std::endl;
     return true;
   }
   res = json_object_get(res, orderId.c_str());
   // open orders exist but specific order not found: return true
-  if (json_object_size(res) == 0)
-  {
+  if (json_object_size(res) == 0) {
     *params.logFile << "<Kraken> Order " << orderId << " does not exist" << std::endl;
     return true;
-    // open orders exist and specific order was found: return false
-  }
-  else
-  {
+  // open orders exist and specific order was found: return false
+  } else {
     *params.logFile << "<Kraken> Order " << orderId << " still exists!" << std::endl;
     return false;
   }
 }
 
-double getActivePos(Parameters &params)
-{
-  return getAvail(params, "btc");
+double getActivePos(Parameters& params, std::string orderId) {
+  double activeSize = 0.0;
+  if (!orderId.empty()){
+    std::string uri = "/0/private/QueryOrders";
+    std::string options = "txid=";
+    options += orderId;
+    unique_json root { authRequest(params, "/0/private/QueryOrders", options) };
+    auto result = json_object_get(root.get(),"result");
+    //SUGGEST: Pretty messy dude
+    std::string tmpord = orderId.c_str();
+    activeSize = atof(json_string_value(json_object_get(json_object_get(result,tmpord.c_str()),"vol")));
+  }
+  return activeSize;
 }
 
 double getLimitPrice(Parameters &params, double volume, bool isBid)
@@ -189,24 +174,27 @@ double getLimitPrice(Parameters &params, double volume, bool isBid)
   double currVol = 0;
   unsigned int i;
   // [[<price>, <volume>, <timestamp>], [<price>, <volume>, <timestamp>], ...]
-  for (i = 0; i < json_array_size(branch); i++)
+  for(i = 0; i < json_array_size(branch); i++)
   {
     // volumes are added up until the requested volume is reached
     currVol = atof(json_string_value(json_array_get(json_array_get(branch, i), 1)));
     currPrice = atof(json_string_value(json_array_get(json_array_get(branch, i), 0)));
     totVol += currVol;
-    if (totVol >= volume * params.orderBookFactor)
-      break;
+    if(totVol >=  volume * params.orderBookFactor)
+        break;
   }
 
   return currPrice;
 }
 
-json_t *authRequest(Parameters &params, std::string request, std::string options)
+json_t* authRequest(Parameters& params, std::string request, std::string options)
 {
   // create nonce and POST data
   static uint64_t nonce = time(nullptr) * 4;
   std::string post_data = "nonce=" + std::to_string(++nonce);
+  
+  
+  
   if (!options.empty())
     post_data += "&" + options;
 
@@ -218,7 +206,7 @@ json_t *authRequest(Parameters &params, std::string request, std::string options
 
   std::string payload_for_signature = std::to_string(nonce) + post_data;
   SHA256((uint8_t *)payload_for_signature.c_str(), payload_for_signature.size(),
-         &sig_data[sig_size - SHA256_DIGEST_LENGTH]);
+         &sig_data[ sig_size - SHA256_DIGEST_LENGTH ]);
 
   std::string decoded_key = base64_decode(params.krakenSecret);
   uint8_t *hmac_digest = HMAC(EVP_sha512(),
@@ -226,9 +214,10 @@ json_t *authRequest(Parameters &params, std::string request, std::string options
                               sig_data.data(), sig_data.size(), NULL, NULL);
   std::string api_sign_header = base64_encode(hmac_digest, SHA512_DIGEST_LENGTH);
   // cURL header
-  std::array<std::string, 2> headers{
-      "API-KEY:" + params.krakenApi,
-      "API-Sign:" + api_sign_header,
+  std::array<std::string, 2> headers
+  {
+    "API-KEY:"  + params.krakenApi,
+    "API-Sign:" + api_sign_header,
   };
 
   // cURL request
@@ -237,43 +226,41 @@ json_t *authRequest(Parameters &params, std::string request, std::string options
                               make_slist(std::begin(headers), std::end(headers)),
                               post_data);
 }
+void testKraken(){
 
-void testKraken()
-{
+    Parameters params("bird.conf");
+    params.logFile = new std::ofstream("./test.log" , std::ofstream::trunc);
 
-  Parameters params("bird.conf");
-  params.logFile = new std::ofstream("./test.log", std::ofstream::trunc);
+    std::string orderId;
 
-  std::string orderId;
+    //std::cout << "Current value LEG1_LEG2 bid: " << getQuote(params).bid() << std::endl;
+    //std::cout << "Current value LEG1_LEG2 ask: " << getQuote(params).ask() << std::endl;
+    //std::cout << "Current balance XMR: " << getAvail(params, "XMR") << std::endl;
+    //std::cout << "Current balance USD: " << getAvail(params, "USD")<< std::endl;
+    //std::cout << "Current balance ETH: " << getAvail(params, "ETH")<< std::endl;
+    //std::cout << "Current balance BTC: " << getAvail(params, "BTC")<< std::endl;
+    //std::cout << "current bid limit price for .09 units: " << getLimitPrice(params, 0.09, true) << std::endl;
+    //std::cout << "Current ask limit price for .09 units: " << getLimitPrice(params, 0.09, false) << std::endl;
+    //std::cout << "Sending buy order for 0.01 XMR @ $100 USD - TXID: " << std::endl;
+    //orderId = sendLongOrder(params, "buy", 0.01, 100);
+    //std::cout << orderId << std::endl;
+    ///// if you don't wait bittrex won't recognize order for iscomplete
+    //sleep(5);
+    //std::cout << "Buy Order is complete: " << isOrderComplete(params, orderId) << std::endl;
 
-  std::cout << "Current value LEG1_LEG2 bid: " << getQuote(params).bid() << std::endl;
-  std::cout << "Current value LEG1_LEG2 ask: " << getQuote(params).ask() << std::endl;
-  std::cout << "Current balance BTC: " << getAvail(params, "btc") << std::endl;
-  std::cout << "Current balance USD: " << getAvail(params, "usd") << std::endl;
-  std::cout << "Current balance ETH: " << getAvail(params, "eth") << std::endl;
-  std::cout << "Current balance XMR: " << getAvail(params, "xmr") << std::endl;
-  std::cout << "current bid limit price for .09 units: " << getLimitPrice(params, 0.09, true) << std::endl;
-  std::cout << "Current ask limit price for .09 units: " << getLimitPrice(params, 0.09, false) << std::endl;
-  //std::cout << "Sending buy order for 0.01 XMR @ $100 USD - TXID: " << std::endl;
-  //orderId = sendLongOrder(params, "buy", 0.01, 100);
-  //std::cout << orderId << std::endl;
-  ///// if you don't wait bittrex won't recognize order for iscomplete
-  //sleep(5);
-  //std::cout << "Buy Order is complete: " << isOrderComplete(params, orderId) << std::endl;
-
-  //std::cout << "Sending Short XMR order for 0.177 XMR @BID! USD: ";
-  //orderId = sendShortOrder(params,"sell",0.133, getLimitPrice(params,0.133,true));
-  //std::cout << orderId << std::endl;
-  //std::cout << "Closing Short XMR order for .09 - TXID: ";
-  //orderId = sendShortOrder(params, "buy", 0.046, getLimitPrice(params,0.046, false));
-  //std::cout << orderId  << std::endl;
-
-  //vanilla sell orders below
-  //std::cout << "Buy order is complete: " << isOrderComplete(params, orderId) << std::endl;
-  //std::cout << "Sending sell order for 0.01 XMR @ 5000 USD - TXID: " << std::endl ;
-  //orderId = sendLongOrder(params, "sell", 0.01, 5000);
-  //std:: cout << orderId << std::endl;
-  //std::cout << "Sell order is complete: " << isOrderComplete(params, orderId) << std::endl;
-  //std::cout << "Active Position: " << getActivePos(params);
+    //std::cout << "Sending Short XMR order for 0.177 XMR @BID! USD: ";
+    //orderId = sendShortOrder(params,"sell",0.133, getLimitPrice(params,0.133,true));
+    //std::cout << orderId << std::endl;
+    //std::cout << "Closing Short XMR order for .09 - TXID: ";
+    //orderId = sendShortOrder(params, "buy", 0.046, getLimitPrice(params,0.046, false));
+    //std::cout << orderId  << std::endl;
+    // TODO: Test sell orders, really should work though.
+    //std::cout << orderId << std::endl;
+    //std::cout << "Buy order is complete: " << isOrderComplete(params, orderId) << std::endl;
+    //std::cout << "Sending sell order for 0.01 XMR @ 5000 USD - TXID: " << std::endl ;
+    //orderId = sendLongOrder(params, "sell", 0.01, 5000);
+    //std:: cout << orderId << std::endl;
+    //std::cout << "Sell order is complete: " << isOrderComplete(params, orderId) << std::endl;
+    //std::cout << "Active Position: " << getActivePos(params, "OV7HHB-LYD56-BEUWB2");
 }
 }

--- a/src/exchanges/kraken.h
+++ b/src/exchanges/kraken.h
@@ -17,18 +17,15 @@ std::string sendLongOrder(Parameters& params, std::string direction, double quan
 
 std::string sendShortOrder(Parameters& params, std::string direction, double quantity, double price);
 
-std::string sendOrder(Parameters& params, std::string direction, double quantity, double price);
-
 bool isOrderComplete(Parameters& params, std::string orderId);
 
-double getActivePos(Parameters& params);
+double getActivePos(Parameters& params, std::string orderId = "");
 
 double getLimitPrice(Parameters& params, double volume, bool isBid);
 
 json_t* authRequest(Parameters& params, std::string request, std::string options = "");
 
 void testKraken();
-
 }
 
 #endif

--- a/src/exchanges/poloniex.cpp
+++ b/src/exchanges/poloniex.cpp
@@ -32,18 +32,15 @@ static json_t* checkResponse(std::ostream &logFile, json_t *root)
   return root;
 }
 
-
-// We use ETH/BTC as there is no USD on Poloniex
-// TODO We could show BTC/USDT
 quote_t getQuote(Parameters &params)
 {
   auto &exchange = queryHandle(params);
   unique_json root { exchange.getRequest("/public?command=returnTicker") };
 
-  const char *quote = json_string_value(json_object_get(json_object_get(root.get(), "BTC_ETH"), "highestBid"));
+  const char *quote = json_string_value(json_object_get(json_object_get(root.get(), "USDT_BTC"), "highestBid"));
   auto bidValue = quote ? std::stod(quote) : 0.0;
 
-  quote = json_string_value(json_object_get(json_object_get(root.get(), "BTC_ETH"), "lowestAsk"));
+  quote = json_string_value(json_object_get(json_object_get(root.get(), "USDT_BTC"), "lowestAsk"));
   auto askValue = quote ? std::stod(quote) : 0.0;
 
   return std::make_pair(bidValue, askValue);
@@ -52,15 +49,28 @@ quote_t getQuote(Parameters &params)
 double getAvail(Parameters &params, std::string currency)
 {
   std::transform(begin(currency), end(currency), begin(currency), ::toupper);
-  std::string options = "account=margin";
+  std::string options = "account=exchange";
+  if (currency.compare("USD")==0) {
+    currency += "T";
+  }
   unique_json root { authRequest(params, "returnAvailableAccountBalances", options) };
-  auto funds = json_string_value(json_object_get(json_object_get(root.get(), "margin"), currency.c_str()));
+  auto funds = json_string_value(json_object_get(json_object_get(root.get(), "exchange"), currency.c_str()));
   return funds ? std::stod(funds) : 0.0;
 }
 
 std::string sendLongOrder(Parameters& params, std::string direction, double quantity, double price) {
-  // TODO
-  return "0";
+  if (direction.compare("buy") != 0 && direction.compare("sell") != 0) {
+    *params.logFile  << "<Poloniex> Error: Neither \"buy\" nor \"sell\" selected" << std::endl;
+    return "0";
+    }
+  //TODO: Real currency string
+  std::string options = "currencyPair=USDT_BTC&rate=";
+  std::string volume = std::to_string(quantity);
+  std::string pricelimit = std::to_string(price);
+  options += pricelimit + "&amount=" + volume; 
+  unique_json root { authRequest(params, direction.c_str(), options) };
+  std::string txid = json_string_value(json_object_get(root.get(),"orderNumber"));
+  return txid;
 }
 
 std::string sendShortOrder(Parameters& params, std::string direction, double quantity, double price) {
@@ -81,14 +91,49 @@ bool isOrderComplete(Parameters& params, std::string orderId)
   return true;
 }
 
-double getActivePos(Parameters& params) {
-  // TODO
-  return 0.0;
+double getActivePos(Parameters& params, std::string orderId) {
+  double activeSize = 0.0;
+  if (!orderId.empty()){
+    std::string options = "orderNumber=";
+    options += orderId;
+    unique_json root {authRequest(params, "returnOrderTrades", options) };
+    size_t arraySize = json_array_size(root.get());
+    double tmpFee = 0.0;
+    double tmpAmount = 0.0;
+    //polo returns weird things - we must loop through all the executed trades (for partial fills)
+    //the actual active size is then SUM(amount*(1-tmpFee)) fee seems to be expressed as a percent
+    for (size_t i = 0; i < arraySize; i++) {
+      tmpFee = atof(json_string_value(json_object_get(json_array_get(root.get(),i),"fee")));
+      tmpAmount = atof(json_string_value(json_object_get(json_array_get(root.get(),i),"amount")));
+      activeSize += tmpAmount*(1-tmpFee);
+    }
+  }
+  return activeSize;
 }
 
 double getLimitPrice(Parameters& params, double volume, bool isBid) {
-  // TODO
-  return 0.0;
+  auto &exchange = queryHandle(params);
+  // TODO: build real curr string
+  //std::string uri = "/public?command=returnOrderBook&currencyPair=";
+  unique_json root { exchange.getRequest("/public?command=returnOrderBook&currencyPair=USDT_BTC") };
+  auto bidask  = json_object_get(root.get(),isBid ? "bids" : "asks");
+  *params.logFile << "<Poloniex> Looking for a limit price to fill "
+                  << std::setprecision(8) << fabs(volume) << " Legx...\n";
+  double tmpVol = 0.0;
+  double p = 0.0;
+  double v;
+  int i = 0;
+  while (tmpVol < fabs(volume) * params.orderBookFactor)
+  {
+    p = atof(json_string_value(json_array_get(json_array_get(bidask,i),0)));
+    v = json_number_value(json_array_get(json_array_get(bidask,i),1));
+    *params.logFile << "<Poloniex> order book: "
+                    << std::setprecision(8) << v << " @$"
+                    << std::setprecision(8) << p << std::endl;
+    tmpVol += v;
+    i++;
+  }
+  return p;
 }
 
 json_t* authRequest(Parameters &params, const char *request, const std::string &options)
@@ -118,5 +163,32 @@ json_t* authRequest(Parameters &params, const char *request, const std::string &
                                               make_slist(begin(headers), end(headers)),
                                               post_body));
 }
-  
+void testPoloniex(){
+
+    Parameters params("bird.conf");
+    params.logFile = new std::ofstream("./test.log" , std::ofstream::trunc);
+
+    std::string orderId;
+
+    //std::cout << "Current value LEG1_LEG2 bid: " << getQuote(params).bid() << std::endl;
+    //std::cout << "Current value LEG1_LEG2 ask: " << getQuote(params).ask() << std::endl;
+    //std::cout << "Current balance BTC: " << getAvail(params, "BTC") << std::endl;
+    //std::cout << "Current balance USD: " << getAvail(params, "USD")<< std::endl;
+    //std::cout << "Current balance ETH: " << getAvail(params, "ETH")<< std::endl;
+    //std::cout << "Current balance LTC: " << getAvail(params, "LTC")<< std::endl;
+    //std::cout << "current bid limit price for .04 units: " << getLimitPrice(params, 0.04, true) << std::endl;
+    //std::cout << "Current ask limit price for 10 units: " << getLimitPrice(params, 10.0, false) << std::endl;
+    //std::cout << "Sending buy order for 0.0011 BTC @ ASK - TXID: " << std::endl;
+    //orderId = sendLongOrder(params, "buy", 0.0011, getLimitPrice(params,0.0011,false));
+    //std::cout << orderId << std::endl;
+    //std::cout << "Buy Order is complete: " << isOrderComplete(params, orderId) << std::endl;
+    //sleep(5);
+    //std::cout << "Sending sell order for 0.003603 BTC @ 10000 USD - TXID: " << std::endl;
+    //orderId = sendLongOrder(params, "sell", 0.003603, 10000);
+    //std::cout << orderId << std::endl;
+    //std::cout << "Sell order is complete: " << isOrderComplete(params, orderId) << std::endl;
+
+    // THE EXECUTED ORDER NUMBER:: 146631728614  146631728614
+    //std::cout << "Active Position: " << getActivePos(params,"146631728614");
+}
 }

--- a/src/exchanges/poloniex.h
+++ b/src/exchanges/poloniex.h
@@ -18,10 +18,11 @@ std::string sendShortOrder(Parameters& params, std::string direction, double qua
 
 bool isOrderComplete(Parameters& params, std::string orderId);
 
-double getActivePos(Parameters& params);
+double getActivePos(Parameters& params, std::string orderId="");
 
 double getLimitPrice(Parameters& params, double volume, bool isBid);
 
+void testPoloniex();
 }
 
 #endif

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6,20 +6,14 @@
 #include "parameters.h"
 #include "check_entry_exit.h"
 #include "exchanges/bitfinex.h"
-#include "exchanges/okcoin.h"
-#include "exchanges/bitstamp.h"
+#include "exchanges/bittrex.h"
 #include "exchanges/gemini.h"
 #include "exchanges/kraken.h"
-#include "exchanges/quadrigacx.h"
-#include "exchanges/itbit.h"
-#include "exchanges/btce.h"
-#include "exchanges/poloniex.h"
 #include "exchanges/gdax.h"
-#include "exchanges/exmo.h"
-#include "exchanges/cexio.h"
+#include "exchanges/binance.h"
+#include "exchanges/poloniex.h"
 #include "utils/send_email.h"
 #include "getpid.h"
-
 #include <curl/curl.h>
 #include <iostream>
 #include <fstream>
@@ -29,86 +23,90 @@
 #include <cmath>
 #include <algorithm>
 
-
 // The 'typedef' declarations needed for the function arrays
 // These functions contain everything needed to communicate with
 // the exchanges, like getting the quotes or the active positions.
 // Each function is implemented in the files located in the 'exchanges' folder.
-typedef quote_t (*getQuoteType) (Parameters& params);
-typedef double (*getAvailType) (Parameters& params, std::string currency);
-typedef std::string (*sendOrderType) (Parameters& params, std::string direction, double quantity, double price);
-typedef bool (*isOrderCompleteType) (Parameters& params, std::string orderId);
-typedef double (*getActivePosType) (Parameters& params);
-typedef double (*getLimitPriceType) (Parameters& params, double volume, bool isBid);
-
+typedef quote_t (*getQuoteType)(Parameters &params);
+typedef double (*getAvailType)(Parameters &params, std::string currency);
+typedef std::string (*sendOrderType)(Parameters &params, std::string direction, double quantity, double price);
+typedef bool (*isOrderCompleteType)(Parameters &params, std::string orderId);
+typedef double (*getActivePosType)(Parameters &params, std::string orderId);
+typedef double (*getLimitPriceType)(Parameters &params, double volume, bool isBid);
 
 // This structure contains the balance of both exchanges,
 // *before* and *after* an arbitrage trade.
 // This is used to compute the performance of the trade,
 // by comparing the balance before and after the trade.
-struct Balance {
+struct Balance
+{
   double leg1, leg2;
   double leg1After, leg2After;
 };
 
-
 // 'main' function.
 // Blackbird doesn't require any arguments for now.
-int main(int argc, char** argv) {
-  std::cout << "Blackbird Bitcoin Arbitrage" << std::endl;
-  std::cout << "DISCLAIMER: USE THE SOFTWARE AT YOUR OWN RISK\n" << std::endl;
+int main(int argc, char **argv)
+{
+  std::cout << "Hunting..." << std::endl;
   // Replaces the C++ global locale with the user-preferred locale
   std::locale mylocale("");
   // Loads all the parameters
-  Parameters params("blackbird.conf");
+  Parameters params("bird.conf");
   // Does some verifications about the parameters
-  if (!params.demoMode) {
-    if (!params.useFullExposure) {
-      if (params.testedExposure < 10.0 && params.leg2.compare("USD") == 0) {
+  if (!params.demoMode)
+  {
+    if (!params.useFullExposure)
+    {
+      if (params.testedExposure < 10.0 && params.leg2.compare("USD") == 0)
+      {
         // TODO do the same check for other currencies. Is there a limi?
         std::cout << "ERROR: Minimum USD needed: $10.00" << std::endl;
-        std::cout << "       Otherwise some exchanges will reject the orders\n" << std::endl;
         exit(EXIT_FAILURE);
       }
-      if (params.testedExposure > params.maxExposure) {
-        std::cout << "ERROR: Test exposure (" << params.testedExposure << ") is above max exposure (" << params.maxExposure << ")\n" << std::endl;
+      if (params.testedExposure > params.maxExposure)
+      {
+        std::cout << "ERROR: Test exposure (" << params.testedExposure << ") is above max exposure (" << params.maxExposure << ")\n"
+                  << std::endl;
         exit(EXIT_FAILURE);
       }
     }
   }
 
-// Connects to the SQLite3 database.
-// This database is used to collect bid and ask information
-// from the exchanges. Not really used for the moment, but
-// would be useful to collect historical bid/ask data.
-  if (createDbConnection(params) != 0) {
-    std::cerr << "ERROR: cannot connect to the database \'" << params.dbFile << "\'\n" << std::endl;
+  // Connects to the SQLite3 database.
+  // This database is used to collect bid and ask information
+  // from the exchanges. Not really used for the moment, but
+  // would be useful to collect historical bid/ask data.
+  if (createDbConnection(params) != 0)
+  {
+    std::cerr << "ERROR: cannot connect to the database \'" << params.dbFile << "\'\n"
+              << std::endl;
     exit(EXIT_FAILURE);
   }
-
-  // We only trade BTC/USD for the moment
-  if (params.leg1.compare("BTC") != 0 || params.leg2.compare("USD") != 0) {
-    std::cout << "ERROR: Valid currency pair is only BTC/USD for now.\n" << std::endl;
+  if (createTradeTable(params) != 0)
+  {
+    std::cerr << "ERROR: problems with database \'" << params.dbFile << "\'\n"
+              << std::endl;
     exit(EXIT_FAILURE);
-  }
+  };
 
   // Function arrays containing all the exchanges functions
   // using the 'typedef' declarations from above.
-  getQuoteType getQuote[11];
-  getAvailType getAvail[11];
-  sendOrderType sendLongOrder[11];
-  sendOrderType sendShortOrder[11];
-  isOrderCompleteType isOrderComplete[11];
-  getActivePosType getActivePos[11];
-  getLimitPriceType getLimitPrice[11];
-  std::string dbTableName[11];
-
+  getQuoteType getQuote[7];
+  getAvailType getAvail[7];
+  sendOrderType sendLongOrder[7];
+  sendOrderType sendShortOrder[7];
+  isOrderCompleteType isOrderComplete[7];
+  getActivePosType getActivePos[7];
+  getLimitPriceType getLimitPrice[7];
+  std::string dbTableName[7];
 
   // Adds the exchange functions to the arrays for all the defined exchanges
   int index = 0;
   if (params.bitfinexEnable &&
-     (params.bitfinexApi.empty() == false || params.demoMode == true)) {
-    params.addExchange("Bitfinex", params.bitfinexFees, true, true);
+      (params.bitfinexApi.empty() == false || params.demoMode == true))
+  {
+    params.addExchange(1, "Bitfinex", params.bitfinexFees, true, true);
     getQuote[index] = Bitfinex::getQuote;
     getAvail[index] = Bitfinex::getAvail;
     sendLongOrder[index] = Bitfinex::sendLongOrder;
@@ -122,40 +120,10 @@ int main(int argc, char** argv) {
 
     index++;
   }
-  if (params.okcoinEnable &&
-     (params.okcoinApi.empty() == false || params.demoMode == true)) {
-    params.addExchange("OKCoin", params.okcoinFees, false, true);
-    getQuote[index] = OKCoin::getQuote;
-    getAvail[index] = OKCoin::getAvail;
-    sendLongOrder[index] = OKCoin::sendLongOrder;
-    sendShortOrder[index] = OKCoin::sendShortOrder;
-    isOrderComplete[index] = OKCoin::isOrderComplete;
-    getActivePos[index] = OKCoin::getActivePos;
-    getLimitPrice[index] = OKCoin::getLimitPrice;
-
-    dbTableName[index] = "okcoin";
-    createTable(dbTableName[index], params);
-
-    index++;
-  }
-  if (params.bitstampEnable &&
-     (params.bitstampClientId.empty() == false || params.demoMode == true)) {
-    params.addExchange("Bitstamp", params.bitstampFees, false, true);
-    getQuote[index] = Bitstamp::getQuote;
-    getAvail[index] = Bitstamp::getAvail;
-    sendLongOrder[index] = Bitstamp::sendLongOrder;
-    isOrderComplete[index] = Bitstamp::isOrderComplete;
-    getActivePos[index] = Bitstamp::getActivePos;
-    getLimitPrice[index] = Bitstamp::getLimitPrice;
-
-    dbTableName[index] = "bitstamp";
-    createTable(dbTableName[index], params);
-
-    index++;
-  }
   if (params.geminiEnable &&
-     (params.geminiApi.empty() == false || params.demoMode == true)) {
-    params.addExchange("Gemini", params.geminiFees, false, true);
+      (params.geminiApi.empty() == false || params.demoMode == true))
+  {
+    params.addExchange(2, "Gemini", params.geminiFees, false, true);
     getQuote[index] = Gemini::getQuote;
     getAvail[index] = Gemini::getAvail;
     sendLongOrder[index] = Gemini::sendLongOrder;
@@ -169,8 +137,9 @@ int main(int argc, char** argv) {
     index++;
   }
   if (params.krakenEnable &&
-     (params.krakenApi.empty() == false || params.demoMode == true)) {
-    params.addExchange("Kraken", params.krakenFees, true, true);
+      (params.krakenApi.empty() == false || params.demoMode == true))
+  {
+    params.addExchange(3, "Kraken", params.krakenFees, true, true);
     getQuote[index] = Kraken::getQuote;
     getAvail[index] = Kraken::getAvail;
     sendLongOrder[index] = Kraken::sendLongOrder;
@@ -184,53 +153,26 @@ int main(int argc, char** argv) {
 
     index++;
   }
-  if (params.itbitEnable &&
-     (params.itbitApi.empty() == false || params.demoMode == true)) {
-    params.addExchange("ItBit", params.itbitFees, false, false);
-    getQuote[index] = ItBit::getQuote;
-    getAvail[index] = ItBit::getAvail;
-    getActivePos[index] = ItBit::getActivePos;
-    getLimitPrice[index] = ItBit::getLimitPrice;
-
-    dbTableName[index] = "itbit";
-    createTable(dbTableName[index], params);
-
-    index++;
-  }
-  if (params.btceEnable &&
-     (params.btceApi.empty() == false || params.demoMode == true)) {
-    params.addExchange("BTC-e", params.btceFees, false, true);
-    getQuote[index] = BTCe::getQuote;
-    getAvail[index] = BTCe::getAvail;
-    sendLongOrder[index] = BTCe::sendLongOrder;
-    isOrderComplete[index] = BTCe::isOrderComplete;
-    getActivePos[index] = BTCe::getActivePos;
-    getLimitPrice[index] = BTCe::getLimitPrice;
-
-    dbTableName[index] = "btce";
-    createTable(dbTableName[index], params);
-
-    index++;
-  }
-  if (params.poloniexEnable &&
-     (params.poloniexApi.empty() == false || params.demoMode == true)) {
-    params.addExchange("Poloniex", params.poloniexFees, true, false);
-    getQuote[index] = Poloniex::getQuote;
-    getAvail[index] = Poloniex::getAvail;
-    sendLongOrder[index] = Poloniex::sendLongOrder;
-    sendShortOrder[index] = Poloniex::sendShortOrder;
-    isOrderComplete[index] = Poloniex::isOrderComplete;
-    getActivePos[index] = Poloniex::getActivePos;
-    getLimitPrice[index] = Poloniex::getLimitPrice;
-
-    dbTableName[index] = "poloniex";
+  if (params.bittrexEnable &&
+      (params.bittrexApi.empty() == false || params.demoMode == true))
+  {
+    params.addExchange(4, "Bittrex", params.bittrexFees, false, true);
+    getQuote[index] = Bittrex::getQuote;
+    getAvail[index] = Bittrex::getAvail;
+    sendLongOrder[index] = Bittrex::sendLongOrder;
+    sendShortOrder[index] = Bittrex::sendShortOrder;
+    isOrderComplete[index] = Bittrex::isOrderComplete;
+    getActivePos[index] = Bittrex::getActivePos;
+    getLimitPrice[index] = Bittrex::getLimitPrice;
+    dbTableName[index] = "bittrex";
     createTable(dbTableName[index], params);
 
     index++;
   }
   if (params.gdaxEnable &&
-     (params.gdaxApi.empty() == false || params.demoMode == true)) {
-    params.addExchange("GDAX", params.gdaxFees, false, true);
+      (params.gdaxApi.empty() == false || params.demoMode == true))
+  {
+    params.addExchange(5, "GDAX", params.gdaxFees, false, true);
     getQuote[index] = GDAX::getQuote;
     getAvail[index] = GDAX::getAvail;
     getActivePos[index] = GDAX::getActivePos;
@@ -242,66 +184,55 @@ int main(int argc, char** argv) {
 
     index++;
   }
-  if (params.quadrigaEnable &&
-         (params.quadrigaApi.empty() == false || params.demoMode == true)) {
-    params.addExchange("QuadrigaCX", params.quadrigaFees, false, true);
-    getQuote[index] = QuadrigaCX::getQuote;
-    getAvail[index] = QuadrigaCX::getAvail;
-    sendLongOrder[index] = QuadrigaCX::sendLongOrder;
-    isOrderComplete[index] = QuadrigaCX::isOrderComplete;
-    getActivePos[index] = QuadrigaCX::getActivePos;
-    getLimitPrice[index] = QuadrigaCX::getLimitPrice;
-
-    dbTableName[index] = "quadriga";
+  if (params.binanceEnable &&
+      (params.binanceApi.empty() == false || params.demoMode == true))
+  {
+    params.addExchange(6, "Binance", params.binanceFees, false, true);
+    getQuote[index] = Binance::getQuote;
+    getAvail[index] = Binance::getAvail;
+    sendLongOrder[index] = Binance::sendLongOrder;
+    sendShortOrder[index] = Binance::sendShortOrder;
+    isOrderComplete[index] = Binance::isOrderComplete;
+    getActivePos[index] = Binance::getActivePos;
+    getLimitPrice[index] = Binance::getLimitPrice;
+    dbTableName[index] = "binance";
     createTable(dbTableName[index], params);
 
     index++;
   }
-  if (params.exmoEnable &&
-         (params.exmoApi.empty() == false || params.demoMode == true)) {
-    params.addExchange("Exmo", params.exmoFees, false, true);
-    getQuote[index] = Exmo::getQuote;
-    getAvail[index] = Exmo::getAvail;
-    sendLongOrder[index] = Exmo::sendLongOrder;
-    isOrderComplete[index] = Exmo::isOrderComplete;
-    getActivePos[index] = Exmo::getActivePos;
-    getLimitPrice[index] = Exmo::getLimitPrice;
-
-    dbTableName[index] = "exmo";
+  if (params.poloniexEnable &&
+      (params.poloniexApi.empty() == false || params.demoMode == true))
+  {
+    params.addExchange(7, "Poloniex", params.poloniexFees, false, true);
+    getQuote[index] = Poloniex::getQuote;
+    getAvail[index] = Poloniex::getAvail;
+    sendLongOrder[index] = Poloniex::sendLongOrder;
+    sendShortOrder[index] = Poloniex::sendShortOrder;
+    isOrderComplete[index] = Poloniex::isOrderComplete;
+    getActivePos[index] = Poloniex::getActivePos;
+    getLimitPrice[index] = Poloniex::getLimitPrice;
+    dbTableName[index] = "poloniex";
     createTable(dbTableName[index], params);
 
     index++;
   }
-  if (params.cexioEnable &&
-         (params.cexioApi.empty() == false || params.demoMode == true)) {
-    params.addExchange("Cexio", params.cexioFees, false, true);
-    getQuote[index] = Cexio::getQuote;
-    getAvail[index] = Cexio::getAvail;
-    sendLongOrder[index] = Cexio::sendLongOrder;
-    sendShortOrder[index] = Cexio::sendShortOrder;
-    isOrderComplete[index] = Cexio::isOrderComplete;
-    getActivePos[index] = Cexio::getActivePos;
-    getLimitPrice[index] = Cexio::getLimitPrice;
 
-    dbTableName[index] = "cexio";
-    createTable(dbTableName[index], params);
-
-    index++;
-  }
-  // We need at least two exchanges to run Blackbird
-  if (index < 2) {
-    std::cout << "ERROR: Blackbird needs at least two Bitcoin exchanges. Please edit the config.json file to add new exchanges\n" << std::endl;
+  // We need at least two exchanges to run
+  if (index < 2)
+  {
+    std::cout << "ERROR: Bird needs at least two Bitcoin exchanges. Please edit the config.json file to add new exchanges\n"
+              << std::endl;
     exit(EXIT_FAILURE);
   }
   // Creates the CSV file that will collect the trade results
   std::string currDateTime = printDateTimeFileName();
-  std::string csvFileName = "output/blackbird_result_" + currDateTime + ".csv";
+  std::string csvFileName = "output/bird_result_" + currDateTime + ".csv";
   std::ofstream csvFile(csvFileName, std::ofstream::trunc);
   csvFile << "TRADE_ID,EXCHANGE_LONG,EXHANGE_SHORT,ENTRY_TIME,EXIT_TIME,DURATION,"
           << "TOTAL_EXPOSURE,BALANCE_BEFORE,BALANCE_AFTER,RETURN"
           << std::endl;
   // Creates the log file where all events will be saved
-  std::string logFileName = "output/blackbird_log_" + currDateTime + ".log";
+  std::string logFileName = "output/bird_log_" + currDateTime + ".log";
   std::ofstream logFile(logFileName, std::ofstream::trunc);
   logFile.imbue(mylocale);
   logFile.precision(2);
@@ -309,44 +240,61 @@ int main(int argc, char** argv) {
   params.logFile = &logFile;
   // Log file header
   logFile << "--------------------------------------------" << std::endl;
-  logFile << "|   Blackbird Bitcoin Arbitrage Log File   |" << std::endl;
-  logFile << "--------------------------------------------\n" << std::endl;
-  logFile << "Blackbird started on " << printDateTime() << "\n" << std::endl;
+  logFile << "|             Arbitrage Log File            |" << std::endl;
+  logFile << "--------------------------------------------\n"
+          << std::endl;
+  logFile << "Arb started on " << printDateTime() << "\n"
+          << std::endl;
 
-  logFile << "Connected to database \'" << params.dbFile << "\'\n" << std::endl;
+  logFile << "Connected to database \'" << params.dbFile << "\'\n"
+          << std::endl;
 
-  if (params.demoMode) {
-    logFile << "Demo mode: trades won't be generated\n" << std::endl;
+  if (params.demoMode)
+  {
+    logFile << "Demo mode: trades won't be generated\n"
+            << std::endl;
   }
 
-  // Shows which pair we are trading (BTC/USD only for the moment)
-  logFile << "Pair traded: " << params.leg1 << "/" << params.leg2 << "\n" << std::endl;
+  // Shows which pair we are trading
+  logFile << "Pair traded: " << params.leg1 << "/" << params.leg2 << "\n"
+          << std::endl;
 
-  std::cout << "Log file generated: " << logFileName << "\nBlackbird is running... (pid " << getpid() << ")\n" << std::endl;
+  std::cout << "Log file generated: " << logFileName << "\nHunting... (pid " << getpid() << ")\n"
+            << std::endl;
   int numExch = params.nbExch();
+  int comboExch = 0;
+
   // The btcVec vector contains details about every exchange,
   // like fees, as specified in bitcoin.h
   std::vector<Bitcoin> btcVec;
   btcVec.reserve(numExch);
   // Creates a new Bitcoin structure within btcVec for every exchange we want to trade on
-  for (int i = 0; i < numExch; ++i) {
-    btcVec.push_back(Bitcoin(i, params.exchName[i], params.fees[i], params.canShort[i], params.isImplemented[i]));
+  for (int i = 0; i < numExch; ++i)
+  {
+    btcVec.push_back(Bitcoin(params.exchId[i], params.exchName[i], params.fees[i], params.canShort[i], params.isImplemented[i]));
+    if (params.canShort[i])
+    {
+      comboExch += 1;
+    }
   }
-
+  // this creates the number of possible trades
+  int realNum = (comboExch - 1) * comboExch + (numExch - comboExch) * comboExch;
   // Inits cURL connections
   params.curl = curl_easy_init();
   // Shows the spreads
   logFile << "[ Targets ]\n"
           << std::setprecision(2)
           << "   Spread Entry:  " << params.spreadEntry * 100.0 << "%\n"
-          << "   Spread Target: " << params.spreadTarget * 100.0  << "%\n";
+          << "   Spread Target: " << params.spreadTarget * 100.0 << "%\n";
 
   // SpreadEntry and SpreadTarget have to be positive,
   // Otherwise we will loose money on every trade.
-  if (params.spreadEntry <= 0.0) {
+  if (params.spreadEntry <= 0.0)
+  {
     logFile << "   WARNING: Spread Entry should be positive" << std::endl;
   }
-  if (params.spreadTarget <= 0.0) {
+  if (params.spreadTarget <= 0.0)
+  {
     logFile << "   WARNING: Spread Target should be positive" << std::endl;
   }
   logFile << std::endl;
@@ -357,44 +305,96 @@ int main(int argc, char** argv) {
   if (!params.demoMode)
     std::transform(getAvail, getAvail + numExch,
                    begin(balance),
-                   [&params]( decltype(*getAvail) apply )
-                   {
-                     Balance tmp {};
-                     tmp.leg1 = apply(params, "btc");
-                     tmp.leg2 = apply(params, "usd");
+                   [&params](decltype(*getAvail) apply) {
+                     Balance tmp{};
+                     tmp.leg1 = apply(params, params.leg1.c_str());
+                     tmp.leg2 = apply(params, params.leg2.c_str());
                      return tmp;
-                   } );
+                   });
 
-  // Checks for a restore.txt file, to see if
-  // the program exited with an open position.
-  Result res;
-  res.reset();
-  bool inMarket = res.loadPartialResult("restore.txt");
+  // TODO: is m that necessary? there must be a way to combine a vec and struct without strict defs.
+  // the tradesVec contains details of every trade executed.
+
+  // Build possible trade vectors
+  Result m;
+  m.reset();
+  //one vector for entries, other for active trades
+  std::vector<Result> entryVec;
+  entryVec.reserve(realNum);
+  std::vector<Result> tradeVec;
+  tradeVec.reserve(realNum);
+  // could just passrealNum in their dec but whatever
+  for (int i = 0; i < numExch; i++)
+  {
+    for (int j = 0; j < numExch; j++)
+    {
+      if (i != j)
+      {
+        if (btcVec[j].getHasShort())
+        {
+          // all of the combinations will be loaded into vectors with exchIds
+          m.idExchLong = i;
+          m.idExchShort = j;
+          entryVec.push_back(m);
+        }
+      }
+    }
+  }
+  int numTrades = getNumTradesOutstanding(params);
+  if (realNum < numTrades)
+  {
+    std::cout << "Error: You have more outstanding positions than possible." << std::endl;
+    std::cout << "You may have enabled/disabled exchanges since last run, Check your Db/exchanges." << std::endl;
+    exit(EXIT_FAILURE);
+  }
+  
+  getTradesFromDb(params, tradeVec);
+
+  if (!tradeVec.empty())
+  {
+    for (int i = 0; i < numExch; i++)
+    {
+      for (size_t j = 0; j < tradeVec.size(); j++)
+      {
+        if (entryVec[i].idExchLong == tradeVec[j].idExchLong && entryVec[i].idExchShort == tradeVec[j].idExchShort){
+          entryVec.erase(entryVec.begin()+i);
+        }
+      }
+    }
+  }
 
   // Writes the current balances into the log file
-  for (int i = 0; i < numExch; ++i) {
+  for (int i = 0; i < numExch; ++i)
+  {
     logFile << "   " << params.exchName[i] << ":\t";
-    if (params.demoMode) {
+    if (params.demoMode)
+    {
       logFile << "n/a (demo mode)" << std::endl;
-    } else if (!params.isImplemented[i]) {
-      logFile << "n/a (API not implemented)" << std::endl;
-    } else {
-      logFile << std::setprecision(2) << balance[i].leg2 << " " << params.leg2 << "\t"
-              << std::setprecision(6) << balance[i].leg1 << " " << params.leg1 << std::endl;
     }
-    if (balance[i].leg1 > 0.0050 && !inMarket) { // FIXME: hard-coded number
-      logFile << "ERROR: All " << params.leg1 << " accounts must be empty before starting Blackbird" << std::endl;
-      exit(EXIT_FAILURE);
+    else if (!params.isImplemented[i])
+    {
+      logFile << "n/a (API not implemented)" << std::endl;
+    }
+    else
+    {
+      logFile << std::setprecision(8) << balance[i].leg2 << " " << params.leg2 << "\t"
+              << std::setprecision(8) << balance[i].leg1 << " " << params.leg1 << std::endl;
     }
   }
   logFile << std::endl;
   logFile << "[ Cash exposure ]\n";
-  if (params.demoMode) {
+  if (params.demoMode)
+  {
     logFile << "   No cash - Demo mode\n";
-  } else {
-    if (params.useFullExposure) {
+  }
+  else
+  {
+    if (params.useFullExposure)
+    {
       logFile << "   FULL exposure used!\n";
-    } else {
+    }
+    else
+    {
       logFile << "   TEST exposure used\n   Value: "
               << std::setprecision(2) << params.testedExposure << '\n';
     }
@@ -406,14 +406,16 @@ int main(int argc, char** argv) {
   tm timeinfo = *localtime(&rawtime);
   using std::this_thread::sleep_for;
   using millisecs = std::chrono::milliseconds;
-  using secs      = std::chrono::seconds;
+  using secs = std::chrono::seconds;
   // Waits for the next 'interval' seconds before starting the loop
-  while ((int)timeinfo.tm_sec % params.interval != 0) {
+  while ((int)timeinfo.tm_sec % params.interval != 0)
+  {
     sleep_for(millisecs(100));
     time(&rawtime);
     timeinfo = *localtime(&rawtime);
   }
-  if (!params.verbose) {
+  if (!params.verbose)
+  {
     logFile << "Running..." << std::endl;
   }
 
@@ -424,32 +426,34 @@ int main(int argc, char** argv) {
   time_t diffTime;
 
   // Main analysis loop
-  while (stillRunning) {
+  while (stillRunning)
+  {
     currTime = mktime(&timeinfo);
     time(&rawtime);
     diffTime = difftime(rawtime, currTime);
     // Checks if we are already too late in the current iteration
     // If that's the case we wait until the next iteration
     // and we show a warning in the log file.
-    if (diffTime > 0) {
+    if (diffTime > 0)
+    {
       logFile << "WARNING: " << diffTime << " second(s) too late at " << printDateTime(currTime) << std::endl;
       timeinfo.tm_sec += (ceil(diffTime / params.interval) + 1) * params.interval;
       currTime = mktime(&timeinfo);
       sleep_for(secs(params.interval - (diffTime % params.interval)));
       logFile << std::endl;
-    } else if (diffTime < 0) {
+    }
+    else if (diffTime < 0)
+    {
       sleep_for(secs(-diffTime));
     }
     // Header for every iteration of the loop
-    if (params.verbose) {
-      if (!inMarket) {
-        logFile << "[ " << printDateTime(currTime) << " ]" << std::endl;
-      } else {
-        logFile << "[ " << printDateTime(currTime) << " IN MARKET: Long " << res.exchNameLong << " / Short " << res.exchNameShort << " ]" << std::endl;
-      }
+    if (params.verbose)
+    {
+      logFile << "[ " << printDateTime(currTime) << " ]" << std::endl;
     }
     // Gets the bid and ask of all the exchanges
-    for (int i = 0; i < numExch; ++i) {
+    for (int i = 0; i < numExch; ++i)
+    {
       auto quote = getQuote[i](params);
       double bid = quote.bid();
       double ask = quote.ask();
@@ -459,14 +463,17 @@ int main(int argc, char** argv) {
 
       // If there is an error with the bid or ask (i.e. value is null),
       // we show a warning but we don't stop the loop.
-      if (bid == 0.0) {
+      if (bid == 0.0)
+      {
         logFile << "   WARNING: " << params.exchName[i] << " bid is null" << std::endl;
       }
-      if (ask == 0.0) {
+      if (ask == 0.0)
+      {
         logFile << "   WARNING: " << params.exchName[i] << " ask is null" << std::endl;
       }
       // Shows the bid/ask information in the log file
-      if (params.verbose) {
+      if (params.verbose)
+      {
         logFile << "   " << params.exchName[i] << ": \t"
                 << std::setprecision(2)
                 << bid << " / " << ask << std::endl;
@@ -475,203 +482,233 @@ int main(int argc, char** argv) {
       btcVec[i].updateData(quote);
       curl_easy_reset(params.curl);
     }
-    if (params.verbose) {
+    if (params.verbose)
+    {
       logFile << "   ----------------------------" << std::endl;
     }
+    // TODO: Reimplement Volatility
     // Stores all the spreads in arrays to
     // compute the volatility. The volatility
     // is not used for the moment.
-    if (params.useVolatility) {
-      for (int i = 0; i < numExch; ++i) {
-        for (int j = 0; j < numExch; ++j) {
-          if (i != j) {
-            if (btcVec[j].getHasShort()) {
-              double longMidPrice = btcVec[i].getMidPrice();
-              double shortMidPrice = btcVec[j].getMidPrice();
-              if (longMidPrice > 0.0 && shortMidPrice > 0.0) {
-                if (res.volatility[i][j].size() >= params.volatilityPeriod) {
-                  res.volatility[i][j].pop_back();
-                }
-                res.volatility[i][j].push_front((longMidPrice - shortMidPrice) / longMidPrice);
-              }
-            }
-          }
-        }
-      }
-    }
+    // if (params.useVolatility) {
+    //   for (int i = 0; i < numExch; ++i) {
+    //     for (int j = 0; j < numExch; ++j) {
+    //       if (i != j) {
+    //         if (btcVec[j].getHasShort()) {
+    //           double longMidPrice = btcVec[i].getMidPrice();
+    //           double shortMidPrice = btcVec[j].getMidPrice();
+    //           if (longMidPrice > 0.0 && shortMidPrice > 0.0) {
+    //             if (res.volatility[i][j].size() >= params.volatilityPeriod) {
+    //               res.volatility[i][j].pop_back();
+    //             }
+    //             res.volatility[i][j].push_front((longMidPrice - shortMidPrice) / longMidPrice);
+    //           }
+    //         }
+    //       }
+    //     }
+    //   }
+    // }
     // Looks for arbitrage opportunities on all the exchange combinations
-    if (!inMarket) {
-      for (int i = 0; i < numExch; ++i) {
-        for (int j = 0; j < numExch; ++j) {
-          if (i != j) {
-            if (checkEntry(&btcVec[i], &btcVec[j], res, params)) {
-              // An entry opportunity has been found!
-              res.exposure = std::min(balance[res.idExchLong].leg2, balance[res.idExchShort].leg2);
-              if (params.demoMode) {
-                logFile << "INFO: Opportunity found but no trade will be generated (Demo mode)" << std::endl;
-                break;
-              }
-              if (res.exposure == 0.0) {
-                logFile << "WARNING: Opportunity found but no cash available. Trade canceled" << std::endl;
-                break;
-              }
-              if (params.useFullExposure == false && res.exposure <= params.testedExposure) {
-                logFile << "WARNING: Opportunity found but no enough cash. Need more than TEST cash (min. $"
-                        << std::setprecision(2) << params.testedExposure << "). Trade canceled" << std::endl;
-                break;
-              }
-              if (params.useFullExposure) {
-                // Removes 1% of the exposure to have
-                // a little bit of margin.
-                res.exposure -= 0.01 * res.exposure;
-                if (res.exposure > params.maxExposure) {
-                  logFile << "WARNING: Opportunity found but exposure ("
-                          << std::setprecision(2)
-                          << res.exposure << ") above the limit\n"
-                          << "         Max exposure will be used instead (" << params.maxExposure << ")" << std::endl;
-                  res.exposure = params.maxExposure;
-                }
-              } else {
-                res.exposure = params.testedExposure;
-              }
-              // Checks the volumes and, based on that, computes the limit prices
-              // that will be sent to the exchanges
-              double volumeLong = res.exposure / btcVec[res.idExchLong].getAsk();
-              double volumeShort = res.exposure / btcVec[res.idExchShort].getBid();
-              double limPriceLong = getLimitPrice[res.idExchLong](params, volumeLong, false);
-              double limPriceShort = getLimitPrice[res.idExchShort](params, volumeShort, true);
-              if (limPriceLong == 0.0 || limPriceShort == 0.0) {
-                logFile << "WARNING: Opportunity found but error with the order books (limit price is null). Trade canceled\n";
-                logFile.precision(2);
-                logFile << "         Long limit price:  " << limPriceLong << std::endl;
-                logFile << "         Short limit price: " << limPriceShort << std::endl;
-                res.trailing[res.idExchLong][res.idExchShort] = -1.0;
-                break;
-              }
-              if (limPriceLong - res.priceLongIn > params.priceDeltaLim || res.priceShortIn - limPriceShort > params.priceDeltaLim) {
-                logFile << "WARNING: Opportunity found but not enough liquidity. Trade canceled\n";
-                logFile.precision(2);
-                logFile << "         Target long price:  " << res.priceLongIn << ", Real long price:  " << limPriceLong << std::endl;
-                logFile << "         Target short price: " << res.priceShortIn << ", Real short price: " << limPriceShort << std::endl;
-                res.trailing[res.idExchLong][res.idExchShort] = -1.0;
-                break;
-              }
-              // We are in market now, meaning we have positions on leg1 (the hedged on)
-              // We store the details of that first trade into the Result structure.
-              inMarket = true;
-              resultId++;
-              res.id = resultId;
-              res.entryTime = currTime;
-              res.priceLongIn = limPriceLong;
-              res.priceShortIn = limPriceShort;
-              res.printEntryInfo(*params.logFile);
-              res.maxSpread[res.idExchLong][res.idExchShort] = -1.0;
-              res.minSpread[res.idExchLong][res.idExchShort] = 1.0;
-              res.trailing[res.idExchLong][res.idExchShort] = 1.0;
-
-              // Send the orders to the two exchanges
-              auto longOrderId = sendLongOrder[res.idExchLong](params, "buy", volumeLong, limPriceLong);
-              auto shortOrderId = sendShortOrder[res.idExchShort](params, "sell", volumeShort, limPriceShort);
-              logFile << "Waiting for the two orders to be filled..." << std::endl;
-              sleep_for(millisecs(5000));
-              bool isLongOrderComplete = isOrderComplete[res.idExchLong](params, longOrderId);
-              bool isShortOrderComplete = isOrderComplete[res.idExchShort](params, shortOrderId);
-              // Loops until both orders are completed
-              while (!isLongOrderComplete || !isShortOrderComplete) {
-                sleep_for(millisecs(3000));
-                if (!isLongOrderComplete) {
-                  logFile << "Long order on " << params.exchName[res.idExchLong] << " still open..." << std::endl;
-                  isLongOrderComplete = isOrderComplete[res.idExchLong](params, longOrderId);
-                }
-                if (!isShortOrderComplete) {
-                  logFile << "Short order on " << params.exchName[res.idExchShort] << " still open..." << std::endl;
-                  isShortOrderComplete = isOrderComplete[res.idExchShort](params, shortOrderId);
-                }
-              }
-              // Both orders are now fully executed
-              logFile << "Done" << std::endl;
-
-              // Stores the partial result to file in case
-              // the program exits before closing the position.
-              res.savePartialResult("restore.txt");
-
-              // Resets the order ids
-              longOrderId  = "0";
-              shortOrderId = "0";
-              break;
-            }
-          }
-        }
-        if (inMarket) {
+    for (size_t i = 0; i < entryVec.size(); i++)
+    {
+      if (checkEntry(&btcVec[entryVec[i].idExchLong], &btcVec[entryVec[i].idExchShort], entryVec[i], params))
+      {
+        // An entry opportunity has been found!
+        entryVec[i].exposure = std::min(balance[entryVec[i].idExchLong].leg2, balance[entryVec[i].idExchShort].leg2);
+        if (params.demoMode)
+        {
+          logFile << "INFO: Opportunity found but no trade will be generated (Demo mode)" << std::endl;
           break;
         }
-      }
-      if (params.verbose) {
-        logFile << std::endl;
-      }
-    } else if (inMarket) {
-      // We are in market and looking for an exit opportunity
-      if (checkExit(&btcVec[res.idExchLong], &btcVec[res.idExchShort], res, params, currTime)) {
-        // An exit opportunity has been found!
-        // We check the current leg1 exposure
-        std::vector<double> btcUsed(numExch);
-        for (int i = 0; i < numExch; ++i) {
-          btcUsed[i] = getActivePos[i](params);
+        if (entryVec[i].exposure == 0.0)
+        {
+          logFile << "WARNING: Opportunity found but no cash available. Trade canceled" << std::endl;
+          break;
         }
-        // Checks the volumes and computes the limit prices that will be sent to the exchanges
-        double volumeLong = btcUsed[res.idExchLong];
-        double volumeShort = btcUsed[res.idExchShort];
-        double limPriceLong = getLimitPrice[res.idExchLong](params, volumeLong, true);
-        double limPriceShort = getLimitPrice[res.idExchShort](params, volumeShort, false);
-        if (limPriceLong == 0.0 || limPriceShort == 0.0) {
+        //TODO: I can put the withdrawal/deposit function here
+        if (params.useFullExposure == false && entryVec[i].exposure <= params.testedExposure)
+        {
+          logFile << "WARNING: Opportunity found but not enough cash. Need more than TEST cash (min. $"
+                  << std::setprecision(2) << params.testedExposure << "). Trade canceled" << std::endl;
+          break;
+        }
+        if (params.useFullExposure)
+        {
+          // Removes 1% of the exposure to have
+          // a little bit of margin.
+          entryVec[i].exposure -= 0.01 * entryVec[i].exposure;
+          if (entryVec[i].exposure > params.maxExposure)
+          {
+            logFile << "WARNING: Opportunity found but exposure ("
+                    << std::setprecision(2)
+                    << entryVec[i].exposure << ") above the limit\n"
+                    << "         Max exposure will be used instead (" << params.maxExposure << ")" << std::endl;
+            entryVec[i].exposure = params.maxExposure;
+          }
+        }
+        else
+        {
+          entryVec[i].exposure = params.testedExposure;
+        }
+        // Checks the volumes and, based on that, computes the limit prices
+        // that will be sent to the exchanges
+        double volumeLong = entryVec[i].exposure / btcVec[entryVec[i].idExchLong].getAsk();
+        double volumeShort = entryVec[i].exposure / btcVec[entryVec[i].idExchShort].getBid();
+        double limPriceLong = getLimitPrice[entryVec[i].idExchLong](params, volumeLong, false);
+        double limPriceShort = getLimitPrice[entryVec[i].idExchShort](params, volumeShort, true);
+        if (limPriceLong == 0.0 || limPriceShort == 0.0)
+        {
           logFile << "WARNING: Opportunity found but error with the order books (limit price is null). Trade canceled\n";
           logFile.precision(2);
           logFile << "         Long limit price:  " << limPriceLong << std::endl;
           logFile << "         Short limit price: " << limPriceShort << std::endl;
-          res.trailing[res.idExchLong][res.idExchShort] = 1.0;
-        } else if (res.priceLongOut - limPriceLong > params.priceDeltaLim || limPriceShort - res.priceShortOut > params.priceDeltaLim) {
+          entryVec[i].trailing = -1.0;
+          break;
+        }
+        if (limPriceLong - entryVec[i].priceLongIn > params.priceDeltaLim || entryVec[i].priceShortIn - limPriceShort > params.priceDeltaLim)
+        {
           logFile << "WARNING: Opportunity found but not enough liquidity. Trade canceled\n";
           logFile.precision(2);
-          logFile << "         Target long price:  " << res.priceLongOut << ", Real long price:  " << limPriceLong << std::endl;
-          logFile << "         Target short price: " << res.priceShortOut << ", Real short price: " << limPriceShort << std::endl;
-          res.trailing[res.idExchLong][res.idExchShort] = 1.0;
-        } else {
-          res.exitTime = currTime;
-          res.priceLongOut = limPriceLong;
-          res.priceShortOut = limPriceShort;
-          res.printExitInfo(*params.logFile);
+          logFile << "         Target long price:  " << entryVec[i].priceLongIn << ", Real long price:  " << limPriceLong << std::endl;
+          logFile << "         Target short price: " << entryVec[i].priceShortIn << ", Real short price: " << limPriceShort << std::endl;
+          entryVec[i].trailing = -1.0;
+          break;
+        }
+        // We are in market now, meaning we have positions on leg1 (the hedged on)
+        // We store the details of that first trade into the Result structure.
+        resultId++;
+        entryVec[i].id = resultId;
+        entryVec[i].entryTime = currTime;
+        entryVec[i].priceLongIn = limPriceLong;
+        entryVec[i].priceShortIn = limPriceShort;
+        entryVec[i].printEntryInfo(*params.logFile);
+        entryVec[i].maxSpread = -1.0;
+        entryVec[i].minSpread = 1.0;
+        entryVec[i].trailing = 1.0;
+        // Send the orders to the two exchanges
+        auto longOrderId = sendLongOrder[entryVec[i].idExchLong](params, "buy", volumeLong, limPriceLong);
+        auto shortOrderId = sendShortOrder[entryVec[i].idExchShort](params, "sell", volumeShort, limPriceShort);
+        logFile << "Waiting for the two orders to be filled..." << std::endl;
+        sleep_for(millisecs(5000));
+        bool isLongOrderComplete = isOrderComplete[entryVec[i].idExchLong](params, longOrderId);
+        bool isShortOrderComplete = isOrderComplete[entryVec[i].idExchShort](params, shortOrderId);
+        // Loops until both orders are completed
+        while (!isLongOrderComplete || !isShortOrderComplete)
+        {
+          sleep_for(millisecs(3000));
+          if (!isLongOrderComplete)
+          {
+            logFile << "Long order on " << params.exchName[entryVec[i].idExchLong] << " still open..." << std::endl;
+            isLongOrderComplete = isOrderComplete[entryVec[i].idExchLong](params, longOrderId);
+          }
+          if (!isShortOrderComplete)
+          {
+            logFile << "Short order on " << params.exchName[entryVec[i].idExchShort] << " still open..." << std::endl;
+            isShortOrderComplete = isOrderComplete[entryVec[i].idExchShort](params, shortOrderId);
+          }
+        }
+        // Both orders are now fully executed
+        logFile << "Done" << std::endl;
+        // Adding new parameters to result file to keep track of executed trades
+        entryVec[i].longExchTradeId = longOrderId;
+        entryVec[i].shortExchTradeId = shortOrderId;
+        // Stores the partial result to file in case
+        // the program exits before closing the position.
+        if (addTradesToDb(entryVec[i], params, 0) != 0)
+        {
+          std::cerr << "ERROR: problems with database \'" << params.dbFile << "\'\n"
+                    << std::endl;
+          exit(EXIT_FAILURE);
+        };
+        tradeVec.push_back(entryVec[i]);
+        entryVec.erase(entryVec.begin() + i);
+        longOrderId = "0";
+        shortOrderId = "0";
+        break;
+      }
+    }
+    if (params.verbose)
+    {
+      logFile << std::endl;
+    }
+    for (size_t i = 0; i < tradeVec.size(); i++)
+    {
+      if (params.verbose)
+      {
+        logFile << "[ " << printDateTime(currTime) << " IN MARKET: Long " << tradeVec[i].exchNameLong << " / Short " << tradeVec[i].exchNameShort << " ]" << std::endl;
+      }
+      if (checkExit(&btcVec[tradeVec[i].idExchLong], &btcVec[tradeVec[i].idExchShort], tradeVec[i], params, currTime))
+      {
+        // An exit opportunity has been found!
+        // We check the current leg1 exposure
+        std::vector<double> btcUsed(realNum);
+        btcUsed[tradeVec[i].idExchLong] = getActivePos[tradeVec[i].idExchLong](params, tradeVec[i].longExchTradeId);
+        btcUsed[tradeVec[i].idExchShort] = getActivePos[tradeVec[i].idExchShort](params, tradeVec[i].shortExchTradeId);
+        // Checks the volumes and computes the limit prices that will be sent to the exchanges
+        double volumeLong = btcUsed[tradeVec[i].idExchLong];
+        double volumeShort = btcUsed[tradeVec[i].idExchShort];
+        double limPriceLong = getLimitPrice[tradeVec[i].idExchLong](params, volumeLong, true);
+        double limPriceShort = getLimitPrice[tradeVec[i].idExchShort](params, volumeShort, false);
+        if (limPriceLong == 0.0 || limPriceShort == 0.0)
+        {
+          logFile << "WARNING: Opportunity found but error with the order books (limit price is null). Trade canceled\n";
+          logFile.precision(2);
+          logFile << "         Long limit price:  " << limPriceLong << std::endl;
+          logFile << "         Short limit price: " << limPriceShort << std::endl;
+          tradeVec[i].trailing = 1.0;
+        }
+        else if (tradeVec[i].priceLongOut - limPriceLong > params.priceDeltaLim || limPriceShort - tradeVec[i].priceShortOut > params.priceDeltaLim)
+        {
+          logFile << "WARNING: Opportunity found but not enough liquidity. Trade canceled\n";
+          logFile.precision(2);
+          logFile << "         Target long price:  " << tradeVec[i].priceLongOut << ", Real long price:  " << limPriceLong << std::endl;
+          logFile << "         Target short price: " << tradeVec[i].priceShortOut << ", Real short price: " << limPriceShort << std::endl;
+          tradeVec[i].trailing = 1.0;
+        }
+        else
+        {
+          tradeVec[i].exitTime = currTime;
+          tradeVec[i].priceLongOut = limPriceLong;
+          tradeVec[i].priceShortOut = limPriceShort;
+          tradeVec[i].printExitInfo(*params.logFile);
 
           logFile.precision(6);
-          logFile << params.leg1 << " exposure on " << params.exchName[res.idExchLong] << ": " << volumeLong << '\n'
-                  << params.leg1 << " exposure on " << params.exchName[res.idExchShort] << ": " << volumeShort << '\n'
+          logFile << params.leg1 << " exposure on " << params.exchName[tradeVec[i].idExchLong] << ": " << volumeLong << '\n'
+                  << params.leg1 << " exposure on " << params.exchName[tradeVec[i].idExchShort] << ": " << volumeShort << '\n'
                   << std::endl;
-          auto longOrderId = sendLongOrder[res.idExchLong](params, "sell", fabs(btcUsed[res.idExchLong]), limPriceLong);
-          auto shortOrderId = sendShortOrder[res.idExchShort](params, "buy", fabs(btcUsed[res.idExchShort]), limPriceShort);
+          auto longOrderId = sendLongOrder[tradeVec[i].idExchLong](params, "sell", fabs(btcUsed[tradeVec[i].idExchLong]), limPriceLong);
+          auto shortOrderId = sendShortOrder[tradeVec[i].idExchShort](params, "buy", fabs(btcUsed[tradeVec[i].idExchShort]), limPriceShort);
           logFile << "Waiting for the two orders to be filled..." << std::endl;
           sleep_for(millisecs(5000));
-          bool isLongOrderComplete = isOrderComplete[res.idExchLong](params, longOrderId);
-          bool isShortOrderComplete = isOrderComplete[res.idExchShort](params, shortOrderId);
+          bool isLongOrderComplete = isOrderComplete[tradeVec[i].idExchLong](params, longOrderId);
+          bool isShortOrderComplete = isOrderComplete[tradeVec[i].idExchShort](params, shortOrderId);
           // Loops until both orders are completed
-          while (!isLongOrderComplete || !isShortOrderComplete) {
+          while (!isLongOrderComplete || !isShortOrderComplete)
+          {
             sleep_for(millisecs(3000));
-            if (!isLongOrderComplete) {
-              logFile << "Long order on " << params.exchName[res.idExchLong] << " still open..." << std::endl;
-              isLongOrderComplete = isOrderComplete[res.idExchLong](params, longOrderId);
+            if (!isLongOrderComplete)
+            {
+              logFile << "Long order on " << params.exchName[tradeVec[i].idExchLong] << " still open..." << std::endl;
+              isLongOrderComplete = isOrderComplete[tradeVec[i].idExchLong](params, longOrderId);
             }
-            if (!isShortOrderComplete) {
-              logFile << "Short order on " << params.exchName[res.idExchShort] << " still open..." << std::endl;
-              isShortOrderComplete = isOrderComplete[res.idExchShort](params, shortOrderId);
+            if (!isShortOrderComplete)
+            {
+              logFile << "Short order on " << params.exchName[tradeVec[i].idExchShort] << " still open..." << std::endl;
+              isShortOrderComplete = isOrderComplete[tradeVec[i].idExchShort](params, shortOrderId);
             }
           }
-          logFile << "Done\n" << std::endl;
-          longOrderId  = "0";
+          logFile << "Done\n"
+                  << std::endl;
+          longOrderId = "0";
           shortOrderId = "0";
-          inMarket = false;
-          for (int i = 0; i < numExch; ++i) {
-            balance[i].leg2After = getAvail[i](params, "usd"); // FIXME: currency hard-coded
-            balance[i].leg1After = getAvail[i](params, "btc"); // FIXME: currency hard-coded
+          //inMarket = false;
+          for (int i = 0; i < numExch; ++i)
+          {
+            balance[i].leg2After = getAvail[i](params, params.leg2.c_str()); // FIXME: currency hard-coded
+            balance[i].leg1After = getAvail[i](params, params.leg1.c_str()); // FIXME: currency hard-coded
           }
-          for (int i = 0; i < numExch; ++i) {
+          for (int i = 0; i < numExch; ++i)
+          {
             logFile << "New balance on " << params.exchName[i] << ":  \t";
             logFile.precision(2);
             logFile << balance[i].leg2After << " " << params.leg2 << " (perf " << balance[i].leg2After - balance[i].leg2 << "), ";
@@ -679,57 +716,81 @@ int main(int argc, char** argv) {
           }
           logFile << std::endl;
           // Update total leg2 balance
-          for (int i = 0; i < numExch; ++i) {
-            res.leg2TotBalanceBefore += balance[i].leg2;
-            res.leg2TotBalanceAfter  += balance[i].leg2After;
+          for (int i = 0; i < numExch; ++i)
+          {
+            tradeVec[i].leg2TotBalanceBefore += balance[i].leg2;
+            tradeVec[i].leg2TotBalanceAfter += balance[i].leg2After;
           }
           // Update current balances
-          for (int i = 0; i < numExch; ++i) {
+          for (int i = 0; i < numExch; ++i)
+          {
             balance[i].leg2 = balance[i].leg2After;
             balance[i].leg1 = balance[i].leg1After;
           }
+
           // Prints the result in the result CSV file
           logFile.precision(2);
-          logFile << "ACTUAL PERFORMANCE: " << "$" << res.leg2TotBalanceAfter - res.leg2TotBalanceBefore << " (" << res.actualPerf() * 100.0 << "%)\n" << std::endl;
-          csvFile << res.id << ","
-                  << res.exchNameLong << ","
-                  << res.exchNameShort << ","
-                  << printDateTimeCsv(res.entryTime) << ","
-                  << printDateTimeCsv(res.exitTime) << ","
-                  << res.getTradeLengthInMinute() << ","
-                  << res.exposure * 2.0 << ","
-                  << res.leg2TotBalanceBefore << ","
-                  << res.leg2TotBalanceAfter << ","
-                  << res.actualPerf() << std::endl;
+          logFile << "ACTUAL PERFORMANCE: "
+                  << "$" << tradeVec[i].leg2TotBalanceAfter - tradeVec[i].leg2TotBalanceBefore << " (" << tradeVec[i].actualPerf() * 100.0 << "%)\n"
+                  << std::endl;
+          csvFile << tradeVec[i].id << ","
+                  << tradeVec[i].exchNameLong << ","
+                  << tradeVec[i].exchNameShort << ","
+                  << printDateTimeCsv(tradeVec[i].entryTime) << ","
+                  << printDateTimeCsv(tradeVec[i].exitTime) << ","
+                  << tradeVec[i].getTradeLengthInMinute() << ","
+                  << tradeVec[i].exposure * 2.0 << ","
+                  << tradeVec[i].leg2TotBalanceBefore << ","
+                  << tradeVec[i].leg2TotBalanceAfter << ","
+                  << tradeVec[i].actualPerf() << std::endl;
           // Sends an email with the result of the trade
-          if (params.sendEmail) {
-            sendEmail(res, params);
+          if (params.sendEmail)
+          {
+            // TODO: Fix
+            sendEmail(tradeVec[i], params);
             logFile << "Email sent" << std::endl;
           }
-          res.reset();
+          if (closeTradeInDb(tradeVec[i], params) != 0)
+          {
+            std::cerr << "ERROR: problems with database \'" << params.dbFile << "\'\n"
+                      << std::endl;
+            exit(EXIT_FAILURE);
+          };
+          if (addTradesToDb(tradeVec[i], params, 1) != 0)
+          {
+            std::cerr << "ERROR: problems with database \'" << params.dbFile << "\'\n"
+                      << std::endl;
+            exit(EXIT_FAILURE);
+          };
+          // I dont think this is correct, tradeVec[i] needs to be reset
+          entryVec.push_back(tradeVec[i]);
+          tradeVec.erase(tradeVec.begin() + i);
           // Removes restore.txt since this trade is done.
           std::ofstream resFile("restore.txt", std::ofstream::trunc);
           resFile.close();
         }
       }
-      if (params.verbose) logFile << '\n';
+      if (params.verbose)
+        logFile << '\n';
     }
     // Moves to the next iteration, unless
     // the maxmum is reached.
     timeinfo.tm_sec += params.interval;
     currIteration++;
-    if (currIteration >= params.debugMaxIteration) {
-      logFile << "Max iteration reached (" << params.debugMaxIteration << ")" <<std::endl;
+    if (currIteration >= params.debugMaxIteration)
+    {
+      logFile << "Max iteration reached (" << params.debugMaxIteration << ")" << std::endl;
       stillRunning = false;
     }
     // Exits if a 'stop_after_notrade' file is found
     // Warning: by default on GitHub the file has a underscore
     // at the end, so Blackbird is not stopped by default.
-    std::ifstream infile("stop_after_notrade");
-    if (infile && !inMarket) {
-      logFile << "Exit after last trade (file stop_after_notrade found)\n";
-      stillRunning = false;
-    }
+    //FIXME: broke this, could use newbool
+    //std::ifstream infile("stop_after_notrade");
+    //if (infile && !inMarket) {
+    //  logFile << "Exit after last trade (file stop_after_notrade found)\n";
+    //  stillRunning = false;
+    //}
   }
   // Analysis loop exited, does some cleanup
   curl_easy_cleanup(params.curl);

--- a/src/result.cpp
+++ b/src/result.cpp
@@ -59,66 +59,14 @@ void Result::printExitInfo(std::ostream &logFile) const {
 
 // not sure to understand how this function is implemented ;-)
 void Result::reset() {
-  typedef std::remove_reference< decltype(minSpread[0][0]) >::type arr2d_t;
-  auto arr2d_size = sizeof(minSpread) / sizeof(arr2d_t);
+  // typedef std::remove_reference< decltype(minSpread[0][0]) >::type arr2d_t;
+  // auto arr2d_size = sizeof(minSpread) / sizeof(arr2d_t);
   Result tmp {};
   std::swap(tmp, *this);
-  // Resets all the values of min, max and trailing arrays to values
-  // that will be erased by the very first value entered in the respective arrays.
-  // That's why the reset value for min is 1.0 and for max is -1.0.
-  std::fill_n(reinterpret_cast<arr2d_t *>(minSpread), arr2d_size, 1.0);
-  std::fill_n(reinterpret_cast<arr2d_t *>(maxSpread), arr2d_size, -1.0);
-  std::fill_n(reinterpret_cast<arr2d_t *>(trailing), arr2d_size, -1.0);
-}
-
-bool Result::loadPartialResult(std::string filename) {
-
-  std::ifstream resFile(filename, std::ifstream::ate);
-  if(!resFile || int(resFile.tellg()) == 0) return false;
-
-  resFile.seekg(0);
-  resFile >> id
-          >> idExchLong   >> idExchShort
-          >> exchNameLong >> exchNameShort
-          >> exposure
-          >> feesLong
-          >> feesShort
-          >> entryTime
-          >> spreadIn
-          >> priceLongIn
-          >> priceShortIn
-          >> leg2TotBalanceBefore
-          >> exitTarget;
-
-  resFile >> maxSpread[idExchLong][idExchShort]
-          >> minSpread[idExchLong][idExchShort]
-          >> trailing[idExchLong][idExchShort]
-          >> trailingWaitCount[idExchLong][idExchShort];
-
-  return true;
-}
-
-void Result::savePartialResult(std::string filename) {
-  std::ofstream resFile(filename, std::ofstream::trunc);
-
-  resFile << id << '\n'
-          << idExchLong << '\n'
-          << idExchShort << '\n'
-          << exchNameLong << '\n'
-          << exchNameShort << '\n'
-          << exposure << '\n'
-          << feesLong << '\n'
-          << feesShort << '\n'
-          << entryTime << '\n'
-          << spreadIn << '\n'
-          << priceLongIn << '\n'
-          << priceShortIn << '\n'
-          << leg2TotBalanceBefore << '\n'
-          << exitTarget << '\n';
-
-  resFile << maxSpread[idExchLong][idExchShort] << '\n'
-          << minSpread[idExchLong][idExchShort] << '\n'
-          << trailing[idExchLong][idExchShort] << '\n'
-          << trailingWaitCount[idExchLong][idExchShort]
-          << std::endl;
+  // // Resets all the values of min, max and trailing arrays to values
+  // // that will be erased by the very first value entered in the respective arrays.
+  // // That's why the reset value for min is 1.0 and for max is -1.0.
+  // std::fill_n(reinterpret_cast<arr2d_t *>(minSpread), arr2d_size, 1.0);
+  // std::fill_n(reinterpret_cast<arr2d_t *>(maxSpread), arr2d_size, -1.0);
+  // std::fill_n(reinterpret_cast<arr2d_t *>(trailing), arr2d_size, -1.0);
 }

--- a/src/result.h
+++ b/src/result.h
@@ -9,7 +9,6 @@
 // Stores the information of a complete
 // long/short trade (2 entry trades, 2 exit trades).
 struct Result {
-  
   unsigned id;
   unsigned idExchLong;
   unsigned idExchShort;
@@ -20,6 +19,9 @@ struct Result {
   std::time_t exitTime;
   std::string exchNameLong;
   std::string exchNameShort;
+
+  std::string longExchTradeId;
+  std::string shortExchTradeId;
   double priceLongIn;
   double priceShortIn;
   double priceLongOut;
@@ -28,11 +30,12 @@ struct Result {
   double spreadOut;
   double exitTarget;
   // FIXME: the arrays should have a dynamic size
-  double minSpread[10][10];
-  double maxSpread[10][10];
-  double trailing[10][10];
-  unsigned trailingWaitCount[10][10];
-  std::list<double> volatility[10][10];
+  double minSpread;
+  double maxSpread;
+  double trailing;
+  unsigned trailingWaitCount;
+  //FIXME: Volatility broken
+  //std::list<double> volatility[10][10];
   double leg2TotBalanceBefore;
   double leg2TotBalanceAfter;
 
@@ -49,13 +52,6 @@ struct Result {
   // Resets the structures
   void reset();
   
-  // Tries to load the state from a previous position
-  // from the restore.txt file.
-  bool loadPartialResult(std::string filename);
-  
-  // Saves the state from a previous position
-  // into the restore.txt file.
-  void savePartialResult(std::string filename);
 };
 
 #endif


### PR DESCRIPTION
HI all, 

Wanted to share my starting point for adding parallel trades in ref to #398 -- This may not build for everyone and if you enable any exchanges other than: 

1. Bittrex
2. Binance
3. GDAX
4. Poloniex
5. Kraken

you are essentially guaranteed to get an error and seg fault at the moment. Notice 2 new exchanges and all exchanges will now require an orderId string when calling their getActiveposition member -- Other highlights include poorly written new db_func members to save/retrieve executed trades to the database file.

I'd welcome any thoughts on this approach -- I'll add more comments//docs so it's easier to see what I'm trying to do when I have a little more time.